### PR TITLE
Remove warning about Firefox 33 from @counter-style demo

### DIFF
--- a/counter-style-demo/css/style.css
+++ b/counter-style-demo/css/style.css
@@ -45,13 +45,6 @@ body {
     float: left;
 }
 
-.compatibility-warning {
-    color: #E05252;
-    margin-top: 10px;
-    border-radius: 4px;
-    font-size: 0.7em;
-}
-
 /* Demo styles */
 
 @counter-style demo-cyclic {
@@ -342,4 +335,3 @@ body {
 .demo-ethiopic-numeric {
     list-style: ethiopic-numeric;
 }
-

--- a/counter-style-demo/index.html
+++ b/counter-style-demo/index.html
@@ -138,7 +138,6 @@ ul {
     <i>Read more about <code>@counter-style</code> on
         <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/@counter-style">Mozilla Developer Network</a></i>
 
-    <div class="compatibility-warning">⚠ Warning: <i>@counter-style</i> currently works only on Firefox 33+</div>
 </div>
     <script src="js/script.js"></script>
 </body>


### PR DESCRIPTION
Removes outdated warning about CSS `@counter-style`  being supported _only_  on Firefox 33.