### PR TITLE
Layout Cookbook - Breadcrumb example with clear intent

### DIFF
--- a/css-cookbook/breadcrumb-navigation--download.html
+++ b/css-cookbook/breadcrumb-navigation--download.html
@@ -28,12 +28,8 @@
             padding: .5em 1em;
         }
 
-        .breadcrumb li::before {
+        .breadcrumb li:not(:first-child)::before {
             content: "→";
-        }
-
-        .breadcrumb li:first-child::before {
-            content: "";
         }
     </style>
 

--- a/css-cookbook/breadcrumb-navigation.html
+++ b/css-cookbook/breadcrumb-navigation.html
@@ -24,12 +24,8 @@
             display: flex;
         }
 
-        .breadcrumb li::before {
+        .breadcrumb li:not(:first-child)::before {
             content: "→";
-        }
-
-        .breadcrumb li:first-child::before {
-            content: "";
         }
     </style>
 </head>
@@ -50,13 +46,9 @@
 .breadcrumb ul {
     display: flex;
 }
-    
-.breadcrumb li::before {
+
+.breadcrumb li:not(:first-child)::before {
     content: "→";
-}
-    
-.breadcrumb li:first-child::before {
-    content: "";
 }
     </textarea>
 


### PR DESCRIPTION
Setting the pseudo-class selector `:not()` paired with `:first-child` removes the need for separate CSS rules to achieve the same effect, but also makes your codes intent clearer by stating you want to select all list items that are not the first child.