### PR TITLE
Grid wrapper example for CSS Layout Cookbook

### DIFF
--- a/css-cookbook/grid-wrapper--download.html
+++ b/css-cookbook/grid-wrapper--download.html
@@ -1,0 +1,73 @@
+<!doctype html>
+
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <!-- this is an example from the MDN Layout Cookbook -->
+  <title>CSS Cookbook: Grid Wrapper</title>
+
+
+  <style>
+    body {
+      background-color: #fff;
+      color: #333;
+      font: 1.2em / 1.5 Helvetica Neue, Helvetica, Arial, sans-serif;
+      padding: 0;
+      margin: 0;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: minmax(20px, 1fr) repeat(6, minmax(0, 130px)) minmax(20px, 1fr);
+      grid-auto-rows: minmax(100px, auto);
+      grid-gap: 10px;
+    }
+
+    .grid>* {
+      border: 2px solid rgb(95, 97, 110);
+      border-radius: .5em;
+      padding: 20px;
+    }
+
+    .full-width {
+      grid-column: 1 / -1;
+    }
+
+    .wrapper {
+      grid-column: 2 / -2;
+    }
+
+    .left-edge {
+      grid-column: 1 / -2;
+    }
+
+    .right-wrapper {
+      grid-column: 4 / -2;
+    }
+  </style>
+
+
+
+</head>
+
+<body>
+
+  <div class="grid">
+    <div class="wrapper">
+      <p>This item aligns to a central “wrapper” – columns that have a maximum width.</p>
+    </div>
+    <div class="full-width">
+      <p>This item aligns to the edge of the grid container.</p>
+    </div>
+    <div class="left-edge">
+      <p>This item aligns to the left edge of the grid container and the right edge of the wrapper.</p>
+    </div>
+    <div class="right-wrapper">
+      <p>This item aligns to the right edge of the “wrapper” columns.</p>
+    </div>
+  </div>
+
+</body>
+
+</html>

--- a/css-cookbook/grid-wrapper.html
+++ b/css-cookbook/grid-wrapper.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>CSS Cookbook: Grid Wrapper</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    .grid {
+      display: grid;
+      grid-template-columns: minmax(20px, 1fr) repeat(6, minmax(0, 60px)) minmax(20px, 1fr);
+      grid-auto-rows: minmax(100px, auto);
+      grid-gap: 10px;
+    }
+
+    .grid > * {
+      border: 2px solid rgb(95, 97, 110);
+      border-radius: .5em;
+      padding: 20px;
+    }
+
+    .full-width {
+      grid-column: 1 / -1;
+    }
+
+    .wrapper {
+      grid-column: 2 / -2;
+    }
+
+    .left-edge {
+      grid-column: 1 / -2;
+    }
+
+    .right-wrapper {
+      grid-column: 4 / -2;
+    }
+    </style>
+
+  <style class="editable">
+    .grid {
+      display: grid;
+      grid-template-columns: minmax(20px, 1fr) repeat(6, minmax(0, 60px)) minmax(20px, 1fr);
+      grid-gap: 10px;
+    }
+
+    .full-width {
+      grid-column: 1 / -1;
+    }
+
+    .wrapper {
+      grid-column: 2 / -2;
+    }
+
+    .left-edge {
+      grid-column: 1 / -2;
+    }
+
+    .right-wrapper {
+      grid-column: 4 / -2;
+    }
+  </style>
+</head>
+
+<body>
+  <section class="preview">
+    <div class="grid">
+      <div class="wrapper">
+        <p>This item aligns to a central “wrapper” – columns that have a maximum width.</p>
+      </div>
+      <div class="full-width">
+        <p>This item aligns to the edge of the grid container.</p>
+      </div>
+      <div class="left-edge">
+        <p>This item aligns to the left edge of the grid container and the right edge of the wrapper.</p>
+      </div>
+      <div class="right-wrapper">
+        <p>This item aligns to the right edge of the “wrapper” columns.</p>
+      </div>
+    </div>
+  </section>
+
+  <textarea class="playable playable-css" style="height: 170px;">
+  .grid {
+    display: grid;
+    grid-template-columns: minmax(20px, 1fr) repeat(6, minmax(0, 60px)) minmax(20px, 1fr);
+    grid-gap: 10px;
+  }
+
+  .full-width {
+    grid-column: 1 / -1;
+  }
+
+  .wrapper {
+    grid-column: 2 / -2;
+  }
+
+  .left-edge {
+    grid-column: 1 / -2;
+  }
+
+  .right-wrapper {
+    grid-column: 4 / -2;
+  }
+  </textarea>
+
+  <textarea class="playable playable-html" style="height: 70px;">
+  <div class="grid">
+
+    <div class="wrapper">
+      <p>This item aligns to a central “wrapper” – columns that have a maximum width.</p>
+    </div>
+
+    <div class="full-width">
+      <p>This item aligns to the edge of the grid container.</p>
+    </div>
+
+    <div class="left-edge">
+      <p>This item aligns to the left edge of the grid container and the right edge of the wrapper.</p>
+    </div>
+
+    <div class="right-wrapper">
+      <p>This item aligns to the right edge of the “wrapper” columns.</p>
+    </div>
+
+  </div>
+  </textarea>
+
+  <!-- leave everything below here alone -->
+  <div class="playable-buttons">
+    <input id="reset" type="button" value="Reset">
+  </div>
+</body>
+<script src="playable.js"></script>
+
+</html>


### PR DESCRIPTION
This is a pattern I use a lot with CSS Grid, consisting of a number of central columns with a maximum width, and a flexible column either side. It enables you to align grid items to the central wrapper or break them out to edge of the grid. I find it really useful and use it on practically every project, so I’d love to contribute it to the Layout Cookbook.