### PR TITLE
Adding a missing solution for an additional question

### DIFF
--- a/learn/tasks/grid/marking.md
+++ b/learn/tasks/grid/marking.md
@@ -29,6 +29,20 @@ I have used the shorthands below, however it would be correct for the student to
  grid-row: 2 / 4;
 }
 ```
+###Additional question
+
+This extra question requires a little of research from the student. One way of achieving this would be to use `order` which we've encountered in the flexbox tutorial.
+```
+.item1 {
+ order: 1
+}
+```
+Another valid solution with `z-index`:
+```
+.item1 {
+ z-index: 1;
+}
+```
 
 ## Grid Layout Three
 


### PR DESCRIPTION
In https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Grid_skills#Grid_Layout_Two there is an additional question:

> Can you now cause the first item to display on top without changing the order of items in the source?

I thought it would be useful to add at least one acceptable solution.
I admit that my text might be improved, as I was focusing more on the solution itself.
@chrisdavidmills I mention you because otherwise no one will approve/deny this