### PR TITLE
Fix media query being always applied

### DIFF
--- a/learn/rwd/float-based-rwd.html
+++ b/learn/rwd/float-based-rwd.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>A simple float-based responsive design</title>
     <style>
       body {


### PR DESCRIPTION
In [Responsive Design](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design#Flexible_grids) the example is not responsive on Chrome
@chrisdavidmills 