### PR TITLE
fix(learn): wrap table rows in <tbody>

### DIFF
--- a/learn/tasks/selectors/pseudo.html
+++ b/learn/tasks/selectors/pseudo.html
@@ -33,30 +33,32 @@
         <p>Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato. Dandelion cucumber earthnut pea peanut soko zucchini.</p>
 
         <table>
-          <tr>
-            <th>Fruits</th>
-            <th>Vegetables</th>
-          </tr>
-          <tr>
-            <td>Apple</td>
-            <td>Potato</td>
-          </tr>
-          <tr>
-            <td>Orange</td>
-            <td>Carrot</td>
-          </tr>
-          <tr>
-            <td>Tomato</td>
-            <td>Parsnip</td>
-          </tr>
-          <tr>
-            <td>Kiwi</td>
-            <td>Onion</td>
-          </tr>
-          <tr>
-            <td>Banana</td>
-            <td>Beet</td>
-          </tr>
+          <tbody>
+            <tr>
+              <th>Fruits</th>
+              <th>Vegetables</th>
+            </tr>
+            <tr>
+              <td>Apple</td>
+              <td>Potato</td>
+            </tr>
+            <tr>
+              <td>Orange</td>
+              <td>Carrot</td>
+            </tr>
+            <tr>
+              <td>Tomato</td>
+              <td>Parsnip</td>
+            </tr>
+            <tr>
+              <td>Kiwi</td>
+              <td>Onion</td>
+            </tr>
+            <tr>
+              <td>Banana</td>
+              <td>Beet</td>
+            </tr>
+          </tbody>
         </table>
       </div>
       
@@ -71,30 +73,32 @@
   <p>Veggies es <a href="http://example.com">bonus vobis</a>, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.</p>
   <p>Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato. Dandelion cucumber earthnut pea peanut soko zucchini.</p>
   <table>
-    <tr>
-      <th>Fruits</th>
-      <th>Vegetables</th>
-    </tr>
-    <tr>
-      <td>Apple</td>
-      <td>Potato</td>
-    </tr>
-    <tr>
-      <td>Orange</td>
-      <td>Carrot</td>
-    </tr>
-    <tr>
-      <td>Tomato</td>
-      <td>Parsnip</td>
-    </tr>
-    <tr>
-      <td>Kiwi</td>
-      <td>Onion</td>
-    </tr>
-    <tr>
-      <td>Banana</td>
-      <td>Beet</td>
-    </tr>
+    <tbody>
+      <tr>
+        <th>Fruits</th>
+        <th>Vegetables</th>
+      </tr>
+      <tr>
+        <td>Apple</td>
+        <td>Potato</td>
+      </tr>
+      <tr>
+        <td>Orange</td>
+        <td>Carrot</td>
+      </tr>
+      <tr>
+        <td>Tomato</td>
+        <td>Parsnip</td>
+      </tr>
+      <tr>
+        <td>Kiwi</td>
+        <td>Onion</td>
+      </tr>
+      <tr>
+        <td>Banana</td>
+        <td>Beet</td>
+      </tr>
+    </tbody>
   </table>
 </div>
     </textarea>


### PR DESCRIPTION
Firefox implicitly inserts \<tbody\> element to the table displayed on the page, while editable html doesn't include it.

In the task you need to select every other row of the table without modifying html. One way to do that is to write following selector:

```
table > th:nth-child(2n + 1) {
}
```
But because \<tr\> is wrapped in \<tbody\>, this selector doesn't work and it's not obvious why without looking in browser inspector.

I just wrapped all rows in \<tbody\> so you can see it in editable html.