### PR TITLE
correcting sticky footer example

### DIFF
--- a/css-cookbook/sticky-footer-flexbox--download.html
+++ b/css-cookbook/sticky-footer-flexbox--download.html
@@ -28,6 +28,7 @@
         .page-header,
         .page-footer {
             flex-grow: 0;
+            flex-shrink: 0;
         }
 
         .page-body {

--- a/css-cookbook/sticky-footer-flexbox--download.html
+++ b/css-cookbook/sticky-footer-flexbox--download.html
@@ -10,25 +10,16 @@
 
 
     <style>
-        html {
-            height:100%;
-            box-sizing: border-box;
-        }
-
+        html, 
         body {
+            box-sizing: border-box;
             height: 100%;
-            background-color: #fff;
-            color: #333;
-            font: 1.2em / 1.5 Helvetica Neue, Helvetica, Arial, sans-serif;
             padding: 0;
             margin: 0;
         }
 
-        * {
-            box-sizing: inherit;
-        }
-
         .wrapper {
+            box-sizing: border-box;
             min-height: 100%;
             display: flex;
             flex-direction: column;
@@ -36,20 +27,27 @@
 
         .page-header,
         .page-footer {
-            background-color: rgb(75, 70, 74);
-            color: #fff;
-            padding: 20px;
-            flex-shrink: 0;
+            flex-grow: 0;
         }
 
         .page-body {
-            padding: 20px;
             flex-grow: 1;
         }
 
-        .preview {
-            height: 400px;
-            overflow: auto;
+        /* For demonstration only, not part of the recipe */
+        body {
+            background-color: #fff;
+            color: #333;
+            font: 1.2em / 1.5 Helvetica Neue, Helvetica, Arial, sans-serif;
+        }
+        .page-header,
+        .page-footer {
+            background-color: rgb(75, 70, 74);
+            color: #fff;
+            padding: 20px;
+        }
+        .page-body {
+            padding: 20px;
         }
     </style>
 

--- a/css-cookbook/sticky-footer-flexbox.html
+++ b/css-cookbook/sticky-footer-flexbox.html
@@ -10,17 +10,15 @@
     <link rel="stylesheet" href="styles.css">
 
     <style>
-        html {
-            height:100%;
+        * {
             box-sizing: border-box;
         }
-
-        * {
-            box-sizing: inherit;
-        }
-
+        html, 
         body {
+            box-sizing: border-box;
             height: 100%;
+            padding: 0;
+            margin: 0;
         }
 
         .page-header,
@@ -28,32 +26,44 @@
             background-color: rgb(75, 70, 74);
             color: #fff;
             padding: 20px;
-            flex-shrink: 0;
         }
 
         .page-body {
             padding: 20px;
-            flex-grow: 1;
         }
 
         .preview {
-            height: 100%;
+            height: 400px;
+            overflow: auto;
+        }
+
+        .playable-css {
+            min-height: 420px;
+            overflow: auto;
+        }
+
+        .playable-html {
+            min-height: 160px;
             overflow: auto;
         }
     </style>
 
     <style class="editable">
+        html, body {
+            box-sizing: border-box;
+            height: 100%;
+            padding: 0;
+            margin: 0;
+        }
         .wrapper {
+            box-sizing: border-box;
             min-height: 100%;
             display: flex;
             flex-direction: column;
         }
-
-        .page-header,
-        .page-footer {
-            flex-shrink: 0;
+        .page-header, .page-footer {
+            flex-grow: 0;
         }
-
         .page-body {
             flex-grow: 1;
         }
@@ -72,31 +82,35 @@
         </div>
     </section>
 
-    <textarea class="playable playable-css">
+<textarea class="playable playable-css">
+html, body {
+    box-sizing: border-box;
+    height: 100%;
+    padding: 0;
+    margin: 0;
+}
 .wrapper {
+    box-sizing: border-box;
     min-height: 100%;
     display: flex;
     flex-direction: column;
 }
-
-.page-header,
-.page-footer {
-    flex-shrink: 0;
+.page-header, .page-footer {
+    flex-grow: 0;
 }
-
 .page-body {
     flex-grow: 1;
 }
 </textarea>
 
-    <textarea class="playable playable-html">
+<textarea class="playable playable-html">
 <div class="wrapper">
     <header class="page-header">This is the header</header>
     <main class="page-body">
         <p>Main page content here, add more if you want to see the footer push down.</p>
     </main>
     <footer class="page-footer">Sticky footer</footer>
-    </div>
+</div>
 </textarea>
 
     <div class="playable-buttons">

--- a/css-cookbook/sticky-footer-flexbox.html
+++ b/css-cookbook/sticky-footer-flexbox.html
@@ -63,6 +63,7 @@
         }
         .page-header, .page-footer {
             flex-grow: 0;
+            flex-shrink: 0;
         }
         .page-body {
             flex-grow: 1;
@@ -97,6 +98,7 @@ html, body {
 }
 .page-header, .page-footer {
     flex-grow: 0;
+    flex-shrink: 0;
 }
 .page-body {
     flex-grow: 1;


### PR DESCRIPTION
The sticky footer example contained a few errors listed below:

- The example CSS did not include the required CSS styles for the HTML and BODY tags.
- The example CSS set the `flex-shrink` on the header and footer, but not `flex-grow`
- Improper indentation on the closing div tag in the HTML.
- The textarea for the example CSS was too short, requiring resizing to see the full example code.
- The preview area was too tall, making it hard to view the example code.
- The page did not properly separate styles used for demonstration, and styles used in the recipe.