### PR TITLE
variable-fonts/font-weight.html: Add font-weight range to @font-face declaration

### DIFF
--- a/variable-fonts/font-weight.html
+++ b/variable-fonts/font-weight.html
@@ -20,6 +20,7 @@
       src: url('fonts/MutatorSans.ttf');
       font-family:'MutatorSans';
       font-style: normal;
+      font-weight: 1 1000;
     }
 
     label {
@@ -48,6 +49,7 @@
   src: url('fonts/MutatorSans.ttf');
   font-family:'MutatorSans';
   font-style: normal;
+  font-weight: 1 1000;
 }
 
 label {


### PR DESCRIPTION
Apparently Chrome and Safari depend on declaring the `font-weight` range in the `@font-face` declaration for variable fonts to behave predictably. For this particular example, changing the font-weight of the element in Chrome had no effect.