### PR TITLE
fix case in flex example

### DIFF
--- a/flow/block-inline/flex.html
+++ b/flow/block-inline/flex.html
@@ -92,7 +92,7 @@
       </textarea>
   <textarea id="code" class="playable-html">
 <div class="container">
-    <div>FLex Item</div>
+    <div>Flex Item</div>
     <div>Flex Item</div>
     <div>
         <div>Children</div>


### PR DESCRIPTION
I think the L in FLex should be uncapitalized. Sorry if it was on purpose.