### PR TITLE
Update sticky-footer--download.html

### DIFF
--- a/css-cookbook/sticky-footer--download.html
+++ b/css-cookbook/sticky-footer--download.html
@@ -49,11 +49,7 @@
         .page-body {
             padding: 20px;
         }
-
-        .preview {
-            height: 400px;
-            overflow: auto;
-        }
+        
     </style>
 
 


### PR DESCRIPTION
".preview" does not refer to any element class. So why does it exist in the css style section?