### PR TITLE
Update specificity-boxes.html: It's only about "specificity" but "order" is also here!

### DIFF
--- a/learn/cascade/specificity-boxes.html
+++ b/learn/cascade/specificity-boxes.html
@@ -133,14 +133,14 @@
     </textarea>
 
     <textarea class="playable playable-html" style="height: 140px;">
-<div id="outer" class="container">
-    <div id="inner" class="container">
-        <ul>
-            <li class="nav"><a href="#">One</a></li>
-            <li class="nav"><a href="#">Two</a></li>
-        </ul>
-    </div>
-</div>
+        <div id="outer" class="container">
+            <div id="inner" class="container">
+                <ul>
+                    <li class="nav"><a href="#">One</a></li>
+                    <li class="nav"><a href="#">Two</a></li>
+                </ul>
+            </div>
+        </div>
     </textarea>
 
     <div class="playable-buttons">

--- a/learn/cascade/specificity-boxes.html
+++ b/learn/cascade/specificity-boxes.html
@@ -6,64 +6,62 @@
     <title>specificity demo</title>
     <link rel="stylesheet" href="../styles.css">
     <style>
-        
+
     </style>
 
     <style class="editable">
-/* specificity: 0101 */
-#outer a {
-  background-color: red;
-}
+        /* specificity: 0201 */
+        #outer #inner a {
+            background-color: blue;
+        }
 
-/* specificity: 0201 */
-#outer #inner a {
-  background-color: blue;
-}
+        /* specificity: 0101 */
+        #outer a {
+            background-color: red;
+        }
 
-/* specificity: 0104 */
-#outer div ul li a {
-  color: yellow;
-}
+        /* specificity: 0113 */
+        #outer div ul .nav a {
+            color: white;
+        }
 
-/* specificity: 0113 */
-#outer div ul .nav a {
-  color: white;
-}
+        /* specificity: 0104 */
+        #outer div ul li a {
+            color: yellow;
+        }
 
-/* specificity: 0024 */
-div div li:nth-child(2) a:hover {
-  border: 10px solid black;
-}
+        /* specificity: 0033 */
+        div div .nav:nth-child(2) a:hover {
+            border: 10px double black;
+        }
 
-/* specificity: 0023 */
-div li:nth-child(2) a:hover {
-  border: 10px dashed black;
-}
+        /* specificity: 0024 */
+        div div li:nth-child(2) a:hover {
+            border: 10px solid black;
+        }
 
-/* specificity: 0033 */
-div div .nav:nth-child(2) a:hover {
-  border: 10px double black;
-}
+        /* specificity: 0023 */
+        div li:nth-child(2) a:hover {
+            border: 10px dashed black;
+        }
 
-a {
-  display: inline-block;
-  line-height: 40px;
-  font-size: 20px;
-  text-decoration: none;
-  text-align: center;
-  width: 200px;
-  margin-bottom: 10px;
-}
+        a {
+            display: inline-block;
+            line-height: 40px;
+            font-size: 20px;
+            text-decoration: none;
+            text-align: center;
+            width: 200px;
+            margin-bottom: 10px;
+        }
 
-ul {
-  padding: 0;
-}
+        ul {
+            padding: 0;
+        }
 
-li {
-  list-style-type: none;
-}
-
-
+        li {
+            list-style-type: none;
+        }
     </style>
 </head>
 
@@ -71,68 +69,67 @@ li {
     <section class="preview">
         <div id="outer" class="container">
             <div id="inner" class="container">
-              <ul>
-                <li class="nav"><a href="#">One</a></li>
-                <li class="nav"><a href="#">Two</a></li>
-              </ul>
+                <ul>
+                    <li class="nav"><a href="#">One</a></li>
+                    <li class="nav"><a href="#">Two</a></li>
+                </ul>
             </div>
-          </div>
+        </div>
     </section>
 
     <textarea class="playable playable-css" style="height: 280px;">
+        /* specificity: 0201 */
+        #outer #inner a {
+            background-color: blue;
+        }
 
-/* specificity: 0101 */
-#outer a {
-    background-color: red;
-}
-        
-/* specificity: 0201 */
-#outer #inner a {
-    background-color: blue;
-}
+        /* specificity: 0101 */
+        #outer a {
+            background-color: red;
+        }
 
-/* specificity: 0104 */
-#outer div ul li a {
-    color: yellow;
-}
+        /* specificity: 0113 */
+        #outer div ul .nav a {
+            color: white;
+        }
 
-/* specificity: 0113 */
-#outer div ul .nav a {
-    color: white;
-}
+        /* specificity: 0104 */
+        #outer div ul li a {
+            color: yellow;
+        }
 
-/* specificity: 0024 */
-div div li:nth-child(2) a:hover {
-    border: 10px solid black;
-}
+        /* specificity: 0033 */
+        div div .nav:nth-child(2) a:hover {
+            border: 10px double black;
+        }
 
-/* specificity: 0023 */
-div li:nth-child(2) a:hover {
-    border: 10px dashed black;
-}
+        /* specificity: 0024 */
+        div div li:nth-child(2) a:hover {
+            border: 10px solid black;
+        }
 
-/* specificity: 0033 */
-div div .nav:nth-child(2) a:hover {
-    border: 10px double black;
-}
+        /* specificity: 0023 */
+        div li:nth-child(2) a:hover {
+            border: 10px dashed black;
+        }
 
-a {
-    display: inline-block;
-    line-height: 40px;
-    font-size: 20px;
-    text-decoration: none;
-    text-align: center;
-    width: 200px;
-    margin-bottom: 10px;
-}
+        a {
+            display: inline-block;
+            line-height: 40px;
+            font-size: 20px;
+            text-decoration: none;
+            text-align: center;
+            width: 200px;
+            margin-bottom: 10px;
+        }
 
-ul {
-    padding: 0;
-}
+        ul {
+            padding: 0;
+        }
 
-li {
-    list-style-type: none;
-}            
+        li {
+            list-style-type: none;
+        }                     
     </textarea>
 
     <textarea class="playable playable-html" style="height: 140px;">


### PR DESCRIPTION
1. "[W]hen two rules apply that have equal specificity, the one that comes last in the CSS is the one that will be used" (from the article).

2. We know that "specificity" overrides "order".

3. When we want to show the true power of specificity rule, we should get "order" out of the way. To do so we just need to show that specificity overrides the order.

4. In the example both "order" and "specificity" act in the same direction.

5. So I changed the position of some CSS selectors in the example code to make more coherent .
 