### PR TITLE
fix(cookbook-breadcrumb-navigation): make example responsive

### DIFF
--- a/css-cookbook/breadcrumb-navigation--download.html
+++ b/css-cookbook/breadcrumb-navigation--download.html
@@ -6,7 +6,6 @@
     <meta charset="utf-8">
     <title>CSS Cookbook: Breadcrumb Navigation</title>
 
-
     <style>
         body {
             background-color: #fff;
@@ -16,24 +15,22 @@
             margin: 0;
         }
 
+        .breadcrumb {
+            padding: 0 .5rem;
+        }
+
         .breadcrumb ul {
+            display: flex;
+            flex-wrap: wrap;
             list-style: none;
             margin: 0;
             padding: 0;
-            display: flex;
         }
 
-        .breadcrumb a,
-        .breadcrumb span {
-            padding: .5em 1em;
-        }
-
-        .breadcrumb li::before {
+        .breadcrumb li:not(:last-child)::after {
+            display: inline-block;
+            margin: 0 .25rem;
             content: "→";
-        }
-
-        .breadcrumb li:first-child::before {
-            content: "";
         }
     </style>
 
@@ -43,9 +40,10 @@
 
     <nav aria-label="Breadcrumb" class="breadcrumb">
         <ul>
-            <li><a href="">Home</a></li>
-            <li><a href="">Category</a></li>
-            <li><a href="">Sub-Category</a></li>
+            <li><a href="#">Home</a></li>
+            <li><a href="#">Category</a></li>
+            <li><a href="#">Sub Category</a></li>
+            <li><a href="#">Type</a></li>
             <li><span aria-current="page">Product</span></li>
         </ul>
     </nav>

--- a/css-cookbook/breadcrumb-navigation.html
+++ b/css-cookbook/breadcrumb-navigation.html
@@ -5,31 +5,23 @@
     <meta charset="utf-8">
     <title>CSS Cookbook: Breadcrumb Navigation</title>
     <link rel="stylesheet" href="styles.css">
-    <style>
+    <style class="editable">
+        .breadcrumb {
+            padding: 0 .5rem;
+        }
+
         .breadcrumb ul {
+            display: flex;
+            flex-wrap: wrap;
             list-style: none;
             margin: 0;
             padding: 0;
         }
 
-        .breadcrumb a,
-        .breadcrumb span {
-            padding: .5em 1em;
-        }
-
-    </style>
-
-    <style class="editable">
-        .breadcrumb ul {
-            display: flex;
-        }
-
-        .breadcrumb li::before {
+        .breadcrumb li:not(:last-child)::after {
+            display: inline-block;
+            margin: 0 .25rem;
             content: "→";
-        }
-
-        .breadcrumb li:first-child::before {
-            content: "";
         }
     </style>
 </head>
@@ -38,34 +30,42 @@
     <section class="preview">
         <nav aria-label="Breadcrumb" class="breadcrumb">
             <ul>
-                <li><a href="">Home</a></li>
-                <li><a href="">Category</a></li>
-                <li><a href="">Sub-Category</a></li>
+                <li><a href="#">Home</a></li>
+                <li><a href="#">Category</a></li>
+                <li><a href="#">Sub Category</a></li>
+                <li><a href="#">Type</a></li>
                 <li><span aria-current="page">Product</span></li>
             </ul>
         </nav>
     </section>
 
-    <textarea class="playable playable-css" style="height: 210px;">
+    <textarea class="playable playable-css" style="height: 300px;">
+.breadcrumb {
+    padding: 0 .5rem;
+}
+
 .breadcrumb ul {
     display: flex;
+    flex-wrap: wrap;
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
     
-.breadcrumb li::before {
+.breadcrumb li:not(:last-child)::after {
+    display: inline-block;
+    margin: 0 .25rem;
     content: "→";
-}
-    
-.breadcrumb li:first-child::before {
-    content: "";
 }
     </textarea>
 
-    <textarea class="playable playable-html" style="height: 170px;">
+    <textarea class="playable playable-html" style="height: 160px;">
 <nav aria-label="Breadcrumb" class="breadcrumb">
     <ul>
-        <li><a href="">Home</a></li>
-        <li><a href="">Category</a></li>
-        <li><a href="">Sub-Category</a></li>
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Category</a></li>
+        <li><a href="#">Sub Category</a></li>
+        <li><a href="#">Type</a></li>
         <li><span aria-current="page">Product</span></li>
     </ul>
 </nav>


### PR DESCRIPTION
- make breadcrumbs wrappable with `flex-wrap: wrap`
- don't hide list-style, margin and padding on ul in example
- links href with dummy hash `#` href


mdn/yari#5912