### PR TITLE
fix:editor-layout: set width to 100% and remove max-width

### DIFF
--- a/learn/styles.css
+++ b/learn/styles.css
@@ -24,8 +24,7 @@ body {
     border: none;
     border-left: 6px solid #558ABB;
     color: #4D4E53;
-    width: 90%;
-    max-width: 700px;
+    width: 100%;
     padding: 10px 10px 0px;
     font-size: 90%;
   }
@@ -40,15 +39,13 @@ body {
 
   .playable-buttons {
     text-align: right;
-    width: 90%;
-    max-width: 700px;
+    width: 100%;
     padding: 5px 10px 5px 26px;
     font-size: 100%;
   }
 
   .preview {
-    width: 90%;
-    max-width: 700px;
+    width: 100%;
     border: 1px solid #4D4E53;
     border-radius: 2px;
     padding: 10px 14px 10px 10px;


### PR DESCRIPTION
This removes `max-width` from both the output container as well as the container for the form elements.

fix #70