### PR TITLE
Best practice value for alpha channel and better contrast/visibility

### DIFF
--- a/learn/tasks/values/color-download.html
+++ b/learn/tasks/values/color-download.html
@@ -43,7 +43,7 @@
       <li class="hex">hex color</li>
       <li class="rgb">RGB color</li>
       <li class="hsl">HSL color</li>
-      <li class="transparency">Alpha value .2</li>
+      <li class="transparency">Alpha value 0.6</li>
     </ul>
 
   </body>

--- a/learn/tasks/values/color.html
+++ b/learn/tasks/values/color.html
@@ -43,7 +43,7 @@
           <li class="hex">hex color</li>
           <li class="rgb">RGB color</li>
           <li class="hsl">HSL color</li>
-          <li class="transparency">Alpha value 0.2</li>
+          <li class="transparency">Alpha value 0.6</li>
         </ul>
     </section>
 
@@ -70,7 +70,7 @@
   <li class="hex">hex color</li>
   <li class="rgb">RGB color</li>
   <li class="hsl">HSL color</li>
-  <li class="transparency">Alpha value 0.2</li>
+  <li class="transparency">Alpha value 0.6</li>
 </ul>
     </textarea>
 

--- a/learn/tasks/values/color.html
+++ b/learn/tasks/values/color.html
@@ -43,7 +43,7 @@
           <li class="hex">hex color</li>
           <li class="rgb">RGB color</li>
           <li class="hsl">HSL color</li>
-          <li class="transparency">Alpha value .2</li>
+          <li class="transparency">Alpha value 0.2</li>
         </ul>
     </section>
 
@@ -70,7 +70,7 @@
   <li class="hex">hex color</li>
   <li class="rgb">RGB color</li>
   <li class="hsl">HSL color</li>
-  <li class="transparency">Alpha value .2</li>
+  <li class="transparency">Alpha value 0.2</li>
 </ul>
     </textarea>
 


### PR DESCRIPTION
setting the alpha value to "0.2" instead of ".2"
it's considered best practice and it's common in style guides like in google ones (https://google.github.io/styleguide/htmlcssguide.html#Leading_0s)

Note [pr #15579](https://github.com/mdn/content/pull/15579) in mdn/content, where I changed the image accordingly.