### PR TITLE
Improve contrast of interactive examples

### DIFF
--- a/learn/tasks/cascade/cascade-download.html
+++ b/learn/tasks/cascade/cascade-download.html
@@ -15,14 +15,14 @@
         margin: 0;
       }
       #outer div ul .nav a {
-        background-color: blue;
+        background-color: yellow;
         padding: 5px;
         display: inline-block;
         margin-bottom: 10px;
       }
 
       div div li a {
-        color: yellow;
+        color: rebeccapurple;
       }
     </style>
   </head>

--- a/learn/tasks/cascade/cascade.html
+++ b/learn/tasks/cascade/cascade.html
@@ -11,14 +11,14 @@
 
     <style class="editable">
     #outer div ul .nav a {
-      background-color: blue;
+      background-color: yellow;
       padding: 5px;
       display: inline-block;
       margin-bottom: 10px;
     }
 
     div div li a {
-      color: yellow;
+      color: rebeccapurple;
     }
     </style>
 </head>
@@ -37,14 +37,14 @@
 
     <textarea class="playable playable-css" style="height: 250px;">
 #outer div ul .nav a {
-  background-color: blue;
+  background-color: yellow;
   padding: 5px;
   display: inline-block;
   margin-bottom: 10px;
 }
 
 div div li a {
-  color: yellow;
+  color: rebeccapurple;
 }               
     </textarea>
 

--- a/learn/tasks/float/float1-download.html
+++ b/learn/tasks/float/float1-download.html
@@ -23,7 +23,8 @@
         width: 150px;
         height: 150px;
         border-radius: 5px;
-        background-color: rgb(207,232,220);
+        background-color: rebeccapurple;
+        color: #fff;
         padding: 1em;
       }
 

--- a/learn/tasks/float/float1.html
+++ b/learn/tasks/float/float1.html
@@ -17,7 +17,8 @@
         width: 150px;
         height: 150px;
         border-radius: 5px;
-        background-color: rgb(207,232,220);
+        background-color: rebeccapurple;
+        color: #fff;
         padding: 1em;
       }
     </style>

--- a/learn/tasks/float/float2-download.html
+++ b/learn/tasks/float/float2-download.html
@@ -23,7 +23,8 @@
         width: 150px;
         height: 150px;
         border-radius: 5px;
-        background-color: rgb(207,232,220);
+        background-color: rebeccapurple;
+        color: #fff;
         padding: 1em;
       }
       .float {

--- a/learn/tasks/float/float2.html
+++ b/learn/tasks/float/float2.html
@@ -17,7 +17,8 @@
         width: 150px;
         height: 150px;
         border-radius: 5px;
-        background-color: rgb(207,232,220);
+        background-color: rebeccapurple;
+        color: #fff;
         padding: 1em;
       }
     </style>

--- a/learn/tasks/float/float3-download.html
+++ b/learn/tasks/float/float3-download.html
@@ -30,7 +30,7 @@
       }
 
       .box {
-        background-color: rgb(79,185,227);
+        background-color: rebeccapurple;
         padding: 10px;
         color: #fff;
       }

--- a/learn/tasks/float/float3.html
+++ b/learn/tasks/float/float3.html
@@ -25,7 +25,7 @@
       }
 
       .box {
-        background-color: rgb(79,185,227);
+        background-color: rebeccapurple;
         padding: 10px;
         color: #fff;
       }


### PR DESCRIPTION
Improve contrast of interactive examples like mentioned in issue [#2054](https://github.com/mdn/interactive-examples/issues/2054).

**important**: note pr [#15579](https://github.com/mdn/content/pull/15579) in mdn/content, where the images where changed accordingly, and pr #74 - ideally, these prs would have to be merged at the same time i think?

>with these changes of the color values, they conform now to the AAA standard according to WCAG