### PR TITLE
Update type-download.html

### DIFF
--- a/learn/tasks/selectors/type-download.html
+++ b/learn/tasks/selectors/type-download.html
@@ -20,15 +20,18 @@
   </head>
 
   <body>
-
+    
     <div class="container">
       <h1>This is a heading</h1>
-      <p>Veggies es
-        <span>bonus vobis</span>, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.</p>
-      <h2>A level 2 heading</h2>
-      <p>Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato. Dandelion cucumber earthnut pea peanut soko zucchini.</p>
+      <p>Veggies es 
+        <span class="alert">bonus vobis</span>, proinde vos postulo <span class="alert stop">essum magis</span> kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.</p>
+      <h2 id="special">A level 2 heading</h2>
+      <p>Gumbo beet greens corn soko endive gumbo gourd.</p>
+      <h2>Another level 2 heading</h2>
+      <p>
+        <span class="alert go">Parsley shallot</span> courgette tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato. Dandelion cucumber earthnut pea peanut soko zucchini.</p>
 
-    </div>
+  </div>
 
   </body>
 


### PR DESCRIPTION
Updated type-download.html with the missing id of special and missing classes of alert, go and stop found on the Selectors Two skill test on this page: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors/Selectors_Tasks.  The reason being that the downloadable version of the starting point of this test doesn't include them, but the instructions for this test wants the reader to complete the test without changing the HTML.