### PR TITLE
Added quotes to the font name

### DIFF
--- a/learn/tasks/cascade/cascade-download.html
+++ b/learn/tasks/cascade/cascade-download.html
@@ -8,7 +8,7 @@
       body {
         background-color: #fff;
         color: #333;
-        font: 1.2em / 1.5 Helvetica Neue, Helvetica, Arial, sans-serif;
+        font: 1.2em / 1.5 "Helvetica Neue", Helvetica, Arial, sans-serif;
         padding: 1em;
         margin: 0;
       }


### PR DESCRIPTION
### Summary
Font names separated by spaces should be under quotes, so added quotes around the font family

### Issue

Fixes : #51 font name without ' '