### PR TITLE
display: two-value -> multi-keyword

### DIFF
--- a/display/multi-keyword/block-flow-root.html
+++ b/display/multi-keyword/block-flow-root.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width" />
-  <title>Two Values of Display: two value syntax</title>
+  <title>Multi-Keyword Values of Display: display: flow-root</title>
 
   <style>
     body {
@@ -49,6 +49,7 @@
       border-radius: 2px;
       padding: 10px 14px 10px 10px;
       margin-bottom: 10px;
+      display: flow-root;
     }
 
     section input {
@@ -56,81 +57,57 @@
       margin: 5px;
     }
 
-    .flex {
-      border: 5px solid #ccc;
-      gap: 10px;
+    .container {
+      background-color: #333;
+      color: #fff;
     }
 
-    .flex > * {
-      border: 2px solid rgb(96, 139, 168);
-      border-radius: 5px;
-      background-color: rgba(96, 139, 168, .2);
+    .item {
+      background-color: #fff;
+      border: 1px solid #999;
+      color: #333;
+      width: 100px;
+      height: 100px;
+      padding: 10px;
     }
 
     
   </style>
   <style class="editable">
-
-    .flex1 {
-      display: block flex;
+    .container {
+      display: flow-root;
     }
 
-    .flex2 {
-      display: inline flex;
+    .item {
+      margin: 10px;
+      float: left;
     }
-
   </style>
 </head>
 
 <body>
   <section>
-<h1>Two values for display</h1>
-
-<div class="flex flex1">
-  <div>Item One</div>
-  <div>Item Two</div>
-  <div>Item Three</div>
-</div>
-
-<p>The first example is a block element with flex children.</p>
-
-<div class="flex flex2">
-  <div>Item One</div>
-  <div>Item Two</div>
-  <div>Item Three</div>
-</div>.
-
-The second example is an inline element with flex children.
+    <div class="container">
+      <div class="item">Floated</div>
+      <p>Text following the float.</p>
+    </div>
 
   </section>
-  <textarea class="playable-css" style="height: 180px;">
-
-.flex1 {
-  display: block flex;
+  <textarea class="playable-css" style="height: 180px">
+.container {
+  display: flow-root;
 }
 
-.flex2 {
-  display: inline flex;
+.item {
+  margin: 10px;
+  float: left;
 }
-
       </textarea>
-  <textarea id="code" class="playable-html" style="height: 280px;">
-<h1>Two values for display</h1>
-
-<div class="flex flex1">
-  <div>Item One</div>
-  <div>Item Two</div>
-  <div>Item Three</div>
+  <textarea id="code" class="playable-html">
+<div class="container">
+  <div class="item">Floated</div>
+  <p>Text following the float.</p>
 </div>
-
-<p>The first example is a block element with flex children.</p>
-
-<div class="flex flex2">
-  <div>Item One</div>
-  <div>Item Two</div>
-  <div>Item Three</div>
-</div>
-The second example is an inline element with flex children.
       </textarea>
   <div class="playable-buttons">
     <input id="reset" type="button" value="Reset">

--- a/display/multi-keyword/inline-block.html
+++ b/display/multi-keyword/inline-block.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width" />
-  <title>Two Values of Display: a span as a flex container</title>
+  <title>Multi-Keyword Values of Display: display: inline-block</title>
 
   <style>
     body {
@@ -49,6 +49,7 @@
       border-radius: 2px;
       padding: 10px 14px 10px 10px;
       margin-bottom: 10px;
+      display: flow-root;
     }
 
     section input {
@@ -56,35 +57,37 @@
       margin: 5px;
     }
 
+    p {
+      width: 300px;
+    }
+
     
   </style>
   <style class="editable">
-    .flex {
-      border: 5px solid #ccc;
-      display: flex;
-      justify-content: space-between;
+    .ib {
+      background-color: rgba(0,0,0,.4);
+      color: #fff;
+      padding: 10px;
+      display: inline-block;
     }
   </style>
 </head>
 
 <body>
   <section>
-    <span class="flex">
-      Some text <em>emphasized text</em>
-    </span>
+    <p>This paragraph has a span <span class="ib">with padding</span> it is an inline-block so the padding is contained and pushes the other line boxes away.</p>
 
   </section>
-  <textarea class="playable-css">
-.flex {
-  border: 5px solid #ccc;
-  display: flex;
-  justify-content: space-between;
+  <textarea class="playable-css" style="height: 180px">
+.ib {
+  background-color: rgba(0,0,0,.4);
+  color: #fff;
+  padding: 10px;
+  display: inline-block;
 }
       </textarea>
   <textarea id="code" class="playable-html">
-<span class="flex">
-  Some text <em>emphasized text</em>
-</span>
+<p>This paragraph has a span <span class="ib">with padding</span> it is an inline-block so the padding is contained and pushes the other line boxes away.</p>
       </textarea>
   <div class="playable-buttons">
     <input id="reset" type="button" value="Reset">

--- a/display/multi-keyword/inline-flex.html
+++ b/display/multi-keyword/inline-flex.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width" />
-  <title>Two Values of Display: an inline flex container</title>
+  <title>Multi-Keyword Values of Display: an inline flex container</title>
 
   <style>
     body {

--- a/display/multi-keyword/multi-keyword-flex.html
+++ b/display/multi-keyword/multi-keyword-flex.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width" />
-  <title>Two Values of Display: display: inline-block</title>
+  <title>Multi-Keyword Values of Display: two value syntax</title>
 
   <style>
     body {
@@ -49,7 +49,6 @@
       border-radius: 2px;
       padding: 10px 14px 10px 10px;
       margin-bottom: 10px;
-      display: flow-root;
     }
 
     section input {
@@ -57,37 +56,81 @@
       margin: 5px;
     }
 
-    p {
-      width: 300px;
+    .flex {
+      border: 5px solid #ccc;
+      gap: 10px;
+    }
+
+    .flex > * {
+      border: 2px solid rgb(96, 139, 168);
+      border-radius: 5px;
+      background-color: rgba(96, 139, 168, .2);
     }
 
     
   </style>
   <style class="editable">
-    .ib {
-      background-color: rgba(0,0,0,.4);
-      color: #fff;
-      padding: 10px;
-      display: inline-block;
+
+    .flex1 {
+      display: block flex;
     }
+
+    .flex2 {
+      display: inline flex;
+    }
+
   </style>
 </head>
 
 <body>
   <section>
-    <p>This paragraph has a span <span class="ib">with padding</span> it is an inline-block so the padding is contained and pushes the other line boxes away.</p>
+<h1>Multiple values for display</h1>
+
+<div class="flex flex1">
+  <div>Item One</div>
+  <div>Item Two</div>
+  <div>Item Three</div>
+</div>
+
+<p>The first example is a block element with flex children.</p>
+
+<div class="flex flex2">
+  <div>Item One</div>
+  <div>Item Two</div>
+  <div>Item Three</div>
+</div>.
+
+The second example is an inline element with flex children.
 
   </section>
-  <textarea class="playable-css" style="height: 180px">
-.ib {
-  background-color: rgba(0,0,0,.4);
-  color: #fff;
-  padding: 10px;
-  display: inline-block;
+  <textarea class="playable-css" style="height: 180px;">
+
+.flex1 {
+  display: block flex;
 }
+
+.flex2 {
+  display: inline flex;
+}
+
       </textarea>
-  <textarea id="code" class="playable-html">
-<p>This paragraph has a span <span class="ib">with padding</span> it is an inline-block so the padding is contained and pushes the other line boxes away.</p>
+  <textarea id="code" class="playable-html" style="height: 280px;">
+<h1>Multiple values for display</h1>
+
+<div class="flex flex1">
+  <div>Item One</div>
+  <div>Item Two</div>
+  <div>Item Three</div>
+</div>
+
+<p>The first example is a block element with flex children.</p>
+
+<div class="flex flex2">
+  <div>Item One</div>
+  <div>Item Two</div>
+  <div>Item Three</div>
+</div>
+The second example is an inline element with flex children.
       </textarea>
   <div class="playable-buttons">
     <input id="reset" type="button" value="Reset">

--- a/display/multi-keyword/span-flex.html
+++ b/display/multi-keyword/span-flex.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width" />
-  <title>Two Values of Display: display: flow-root</title>
+  <title>Multi-Keyword Values of Display: a span as a flex container</title>
 
   <style>
     body {
@@ -49,7 +49,6 @@
       border-radius: 2px;
       padding: 10px 14px 10px 10px;
       margin-bottom: 10px;
-      display: flow-root;
     }
 
     section input {
@@ -57,57 +56,35 @@
       margin: 5px;
     }
 
-    .container {
-      background-color: #333;
-      color: #fff;
-    }
-
-    .item {
-      background-color: #fff;
-      border: 1px solid #999;
-      color: #333;
-      width: 100px;
-      height: 100px;
-      padding: 10px;
-    }
-
     
   </style>
   <style class="editable">
-    .container {
-      display: flow-root;
-    }
-
-    .item {
-      margin: 10px;
-      float: left;
+    .flex {
+      border: 5px solid #ccc;
+      display: flex;
+      justify-content: space-between;
     }
   </style>
 </head>
 
 <body>
   <section>
-    <div class="container">
-      <div class="item">Floated</div>
-      <p>Text following the float.</p>
-    </div>
+    <span class="flex">
+      Some text <em>emphasized text</em>
+    </span>
 
   </section>
-  <textarea class="playable-css" style="height: 180px">
-.container {
-  display: flow-root;
-}
-
-.item {
-  margin: 10px;
-  float: left;
+  <textarea class="playable-css">
+.flex {
+  border: 5px solid #ccc;
+  display: flex;
+  justify-content: space-between;
 }
       </textarea>
   <textarea id="code" class="playable-html">
-<div class="container">
-  <div class="item">Floated</div>
-  <p>Text following the float.</p>
-</div>
+<span class="flex">
+  Some text <em>emphasized text</em>
+</span>
       </textarea>
   <div class="playable-buttons">
     <input id="reset" type="button" value="Reset">


### PR DESCRIPTION
This PR renames "two-value" syntax to "multi-keyword" syntax. In our content, we use "two-value" as the name, but in both BCD and the spec, it is defined as "multi-keyword".

Sister PR to https://github.com/mdn/content/pull/24344.
