### PR TITLE
'devanagiri' changed to 'devanagari'

### DIFF
--- a/counter-style-demo/js/script.js
+++ b/counter-style-demo/js/script.js
@@ -175,10 +175,10 @@
             ].join('')
         },
 
-        'devanagiri': {
+        'devanagari': {
             code: [
                 'ul {\n',
-                '  list-style: devanagiri;\n',
+                '  list-style: devanagari;\n',
                 '}',
             ].join('')
         },


### PR DESCRIPTION
Found typos in the index, css, and js files for the counter-style demo page that made the devanagari list style not function properly. 

changed occurrences of 'devanagiri' to 'devanagari'