### PR TITLE
Update CSS to fix margin bottom of learn/media-queries/grid.html

### DIFF
--- a/learn/media-queries/grid.html
+++ b/learn/media-queries/grid.html
@@ -41,6 +41,10 @@
         background-color: rgba(207, 232, 220, 0.7);
       }
 
+      .content {
+        margin-bottom: 1em;
+      }
+
       .related {
         background-color: rgba(79, 185, 227, 0.3);
         border: 1px solid rgb(79, 185, 227);


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/24713
- add a margin such that when the width of the page is reduced, the grid item will not be directly in contact with the aside.

Before:
![image](https://user-images.githubusercontent.com/41845017/221742563-6eabde22-c1f5-4146-b53b-aedad17eb288.png)
After:
![image](https://user-images.githubusercontent.com/41845017/221742635-aa1b4ac3-e6a7-49f9-8a7a-1ae3d048ab4a.png)
