### PR TITLE
Colorpicker: modernize CSS & colors

### DIFF
--- a/tools/color-picker/index.html
+++ b/tools/color-picker/index.html
@@ -1,14 +1,11 @@
 <!DOCTYPE html>
-
-<html lang="en">
+<html lang="en-US">
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8"/>
     <title>Color picker</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css"/>
   </head>
-
   <body>
-
     <div id="container">
         <div id="palette" class="block">
             <div id="color-palette"></div>
@@ -16,7 +13,6 @@
                 <div class="title"> CSS Color </div>
             </div>
         </div>
-
         <div id="picker" class="block">
             <div class="ui-color-picker" data-topic="picker" data-mode="HSL"></div>
             <div id="picker-samples" sample-id="master"></div>
@@ -27,14 +23,11 @@
                 <div id="void-sample" class="icon"></div>
             </div>
         </div>
-
         <div id="canvas" data-tutorial="drop">
             <div id="zindex" class="ui-input-slider" data-topic="z-index" data-info="z-index"
                 data-max="20" data-sensitivity="10"></div>
         </div>
     </div>
-
   <script src="script.js"></script>
   </body>
-
 </html>

--- a/tools/color-picker/script.js
+++ b/tools/color-picker/script.js
@@ -12,7 +12,7 @@ var UIColorPicker = (function UIColorPicker() {
 	/**
 	 * RGBA Color class
 	 *
-	 * HSV/HSB and HSL (hue, saturation, value / brightness, lightness)
+	 * HWB/HSB and HSL (hue, saturation, value / brightness, lightness)
 	 * @param hue			0-360
 	 * @param saturation	0-100
 	 * @param value 		0-100
@@ -34,7 +34,7 @@ var UIColorPicker = (function UIColorPicker() {
 		this.saturation = 0;
 		this.value = 0;
 		this.lightness = 0;
-		this.format = 'HSV';
+		this.format = 'HWB';
 	}
 
 	function RGBColor(r, g, b) {
@@ -49,15 +49,15 @@ var UIColorPicker = (function UIColorPicker() {
 		return color;
 	}
 
-	function HSVColor(h, s, v) {
+	function HWBColor(h, s, v) {
 		var color = new Color();
-		color.setHSV(h, s, v);
+		color.setHWB(h, s, v);
 		return color;
 	}
 
-	function HSVAColor(h, s, v, a) {
+	function HWBAColor(h, s, v, a) {
 		var color = new Color();
-		color.setHSV(h, s, v);
+		color.setHWB(h, s, v);
 		color.a = a;
 		return color;
 	}
@@ -93,8 +93,8 @@ var UIColorPicker = (function UIColorPicker() {
 	};
 
 	Color.prototype.setFormat = function setFormat(format) {
-		if (format === 'HSV')
-			this.format = 'HSV';
+		if (format === 'HWB')
+			this.format = 'HWB';
 		if (format === 'HSL')
 			this.format = 'HSL';
 	};
@@ -130,11 +130,11 @@ var UIColorPicker = (function UIColorPicker() {
 		}
 	};
 
-	Color.prototype.setHSV = function setHSV(hue, saturation, value) {
+	Color.prototype.setHWB = function setHWB(hue, saturation, value) {
 		this.hue = hue;
 		this.saturation = saturation;
 		this.value = value;
-		this.HSVtoRGB();
+		this.HWBtoRGB();
 	};
 
 	Color.prototype.setHSL = function setHSL(hue, saturation, lightness) {
@@ -165,7 +165,7 @@ var UIColorPicker = (function UIColorPicker() {
 			value < 0 || value > 100)
 			return;
 		this.value = value;
-		this.HSVtoRGB();
+		this.HWBtoRGB();
 	};
 
 	Color.prototype.setLightness = function setLightness(value) {
@@ -193,7 +193,7 @@ var UIColorPicker = (function UIColorPicker() {
 		this.b = parseInt(value.substr(4, 2), 16);
 
 		this.alpha	= 1;
-		this.RGBtoHSV();
+		this.RGBtoHWB();
 	};
 
 	/*========== Conversion Methods ==========*/
@@ -206,19 +206,19 @@ var UIColorPicker = (function UIColorPicker() {
 		this.RGBtoHSL();
 	};
 
-	Color.prototype.convertToHSV = function convertToHSV() {
-		if (this.format === 'HSV')
+	Color.prototype.convertToHWB = function convertToHWB() {
+		if (this.format === 'HWB')
 			return;
 
-		this.setFormat('HSV');
-		this.RGBtoHSV();
+		this.setFormat('HWB');
+		this.RGBtoHWB();
 	};
 
 	/*========== Update Methods ==========*/
 
 	Color.prototype.updateRGB = function updateRGB() {
-		if (this.format === 'HSV') {
-			this.HSVtoRGB();
+		if (this.format === 'HWB') {
+			this.HWBtoRGB();
 			return;
 		}
 
@@ -229,8 +229,8 @@ var UIColorPicker = (function UIColorPicker() {
 	};
 
 	Color.prototype.updateHSX = function updateHSX() {
-		if (this.format === 'HSV') {
-			this.RGBtoHSV();
+		if (this.format === 'HWB') {
+			this.RGBtoHWB();
 			return;
 		}
 
@@ -240,7 +240,7 @@ var UIColorPicker = (function UIColorPicker() {
 		}
 	};
 
-	Color.prototype.HSVtoRGB = function HSVtoRGB() {
+	Color.prototype.HWBtoRGB = function HWBtoRGB() {
 		var sat = this.saturation / 100;
 		var value = this.value / 100;
 		var C = sat * value;
@@ -282,7 +282,7 @@ var UIColorPicker = (function UIColorPicker() {
 		if (H >= 5 && H < 6) {	this.setRGBA(C, m, X);	return; }
 	};
 
-	Color.prototype.RGBtoHSV = function RGBtoHSV() {
+	Color.prototype.RGBtoHWB = function RGBtoHWB() {
 		var red		= this.r / 255;
 		var green	= this.g / 255;
 		var blue	= this.b / 255;
@@ -347,13 +347,13 @@ var UIColorPicker = (function UIColorPicker() {
 
 	Color.prototype.getRGBA = function getRGBA() {
 
-		var rgb = '(' + this.r + ', ' + this.g + ', ' + this.b;
+		var rgb = '(' + this.r + ' ' + this.g + ' ' + this.b;
 		var a = '';
 		var v = '';
 		var x = parseFloat(this.a);
 		if (x !== 1) {
-			a = 'a';
-			v = ', ' + x;
+			a = '';
+			v = ' / ' + x;
 		}
 
 		var value = 'rgb' + a + rgb + v + ')';
@@ -361,7 +361,7 @@ var UIColorPicker = (function UIColorPicker() {
 	};
 
 	Color.prototype.getHSLA = function getHSLA() {
-		if (this.format === 'HSV') {
+		if (this.format === 'HWB') {
 			var color = new Color(this);
 			color.setFormat('HSL');
 			color.updateHSX();
@@ -370,11 +370,11 @@ var UIColorPicker = (function UIColorPicker() {
 
 		var a = '';
 		var v = '';
-		var hsl = '(' + this.hue + ', ' + this.saturation + '%, ' + this.lightness +'%';
+		var hsl = '(' + this.hue + ' ' + this.saturation + '% ' + this.lightness +'%';
 		var x = parseFloat(this.a);
 		if (x !== 1) {
-			a = 'a';
-			v = ', ' + x;
+			a = '';
+			v = ' / ' + x;
 		}
 
 		var value = 'hsl' + a + hsl + v + ')';
@@ -416,7 +416,7 @@ var UIColorPicker = (function UIColorPicker() {
 		var topic = this.node.getAttribute('data-topic');
 
 		this.topic = topic;
-		this.picker_mode = (type === 'HSL') ? 'HSL' : 'HSV';
+		this.picker_mode = (type === 'HSL') ? 'HSL' : 'HWB';
 		this.color.setFormat(this.picker_mode);
 
 		this.createPickingArea();
@@ -539,10 +539,10 @@ var UIColorPicker = (function UIColorPicker() {
 		var button = document.createElement('div');
 		button.className = 'switch_mode';
 		button.addEventListener('click', function() {
-			if (this.picker_mode === 'HSV')
+			if (this.picker_mode === 'HWB')
 				this.setPickerMode('HSL');
 			else
-				this.setPickerMode('HSV');
+				this.setPickerMode('HWB');
 
 		}.bind(this));
 
@@ -569,8 +569,8 @@ var UIColorPicker = (function UIColorPicker() {
 		var value = 100 - (y * 100 / size) | 0;
 		var saturation = x * 100 / size | 0;
 
-		if (this.picker_mode === 'HSV')
-			this.color.setHSV(this.color.hue, saturation, value);
+		if (this.picker_mode === 'HWB')
+			this.color.setHWB(this.color.hue, saturation, value);
 		if (this.picker_mode === 'HSL')
 			this.color.setHSL(this.color.hue, saturation, value);
 
@@ -662,7 +662,7 @@ var UIColorPicker = (function UIColorPicker() {
 		var value = 0;
 		var offset = 5;
 
-		if (this.picker_mode === 'HSV')
+		if (this.picker_mode === 'HWB')
 			value = this.color.value;
 		if (this.picker_mode === 'HSL')
 			value = this.color.lightness;
@@ -698,7 +698,7 @@ var UIColorPicker = (function UIColorPicker() {
 
 	ColorPicker.prototype.updatePickerBackground = function updatePickerBackground() {
 		var nc = new Color(this.color);
-		nc.setHSV(nc.hue, 100, 100);
+		nc.setHWB(nc.hue, 100, 100);
 		this.picking_area.style.backgroundColor = nc.getHexa();
 	};
 
@@ -830,7 +830,7 @@ var UIColorPicker = (function UIColorPicker() {
 	};
 
 	ColorPicker.prototype.setPickerMode = function setPickerMode(mode) {
-		if (mode !== 'HSV' && mode !== 'HSL')
+		if (mode !== 'HWB' && mode !== 'HSL')
 			return;
 
 		this.picker_mode = mode;
@@ -890,8 +890,8 @@ var UIColorPicker = (function UIColorPicker() {
 		Color : Color,
 		RGBColor : RGBColor,
 		RGBAColor : RGBAColor,
-		HSVColor : HSVColor,
-		HSVAColor : HSVAColor,
+		HWBColor : HWBColor,
+		HWBAColor : HWBAColor,
 		HSLColor : HSLColor,
 		HSLAColor : HSLAColor,
 		setColor : setColor,
@@ -1541,14 +1541,9 @@ var ColorPickerTool = (function ColorPickerTool() {
 		var HSLA;
 
 		var updateInfo = function updateInfo(color) {
-			if (color.a | 0 === 1) {
-				RGBA.info.textContent = 'RGB';
-				HSLA.info.textContent = 'HSL';
-			}
-			else {
-				RGBA.info.textContent = 'RGBA';
-				HSLA.info.textContent = 'HSLA';
-			}
+      RGBA.info.textContent = 'RGB';
+      HSLA.info.textContent = 'HSL';
+      HEXA.info.textContent = 'HEX';
 
 			RGBA.value.value = color.getRGBA();
 			HSLA.value.value = color.getHSLA();
@@ -2028,16 +2023,16 @@ var ColorPickerTool = (function ColorPickerTool() {
 			var parent = getElemById('controls');
 			var icon = document.createElement('div');
 			var button = document.createElement('div');
-			var hsv = document.createElement('div');
+			var HWB = document.createElement('div');
 			var hsl = document.createElement('div');
 			var active = null;
 
 			icon.className = 'icon picker-icon';
 			button.className = 'switch';
-			button.appendChild(hsv);
+			button.appendChild(HWB);
 			button.appendChild(hsl);
 
-			hsv.textContent = 'HSV';
+			HWB.textContent = 'HWB';
 			hsl.textContent = 'HSL';
 
 			active = hsl;
@@ -2052,14 +2047,14 @@ var ColorPickerTool = (function ColorPickerTool() {
 
 			var picker_sw = new StateButton(icon);
 			picker_sw.subscribe(function() {
-				if (active === hsv)
+				if (active === HWB)
 					switchPickingModeTo(hsl);
 				else
-					switchPickingModeTo(hsv);
+					switchPickingModeTo(HWB);
 			});
 
-			hsv.addEventListener('click', function() {
-				switchPickingModeTo(hsv);
+			HWB.addEventListener('click', function() {
+				switchPickingModeTo(HWB);
 			});
 			hsl.addEventListener('click', function() {
 				switchPickingModeTo(hsl);

--- a/tools/color-picker/styles.css
+++ b/tools/color-picker/styles.css
@@ -213,7 +213,7 @@
 .ui-color-picker .preview-color {
 	width: 100%;
 	height: 100%;
-	background-color: rgb(255 0 0 0.5);
+	background-color: rgb(255 0 0 / 0.5);
 	position: absolute;
 	z-index: 1;
 }

--- a/tools/color-picker/styles.css
+++ b/tools/color-picker/styles.css
@@ -8,10 +8,6 @@
 	border: 1px solid #DDD;
 	background-color: #FFF;
 	display: table;
-
-	-moz-user-select: none;
-	-webkit-user-select: none;
-	-ms-user-select: none;
 	user-select: none;
 }
 
@@ -33,32 +29,25 @@
 .ui-color-picker .picking-area {
 	background: url('picker_mask_200.png') center center;
 
-	background: -moz-linear-gradient(bottom, #000 0%, rgba(0, 0, 0, 0) 100%),
-				-moz-linear-gradient(left, #FFF 0%, rgba(255, 255, 255, 0) 100%);
-	background: -webkit-linear-gradient(bottom, #000 0%, rgba(0, 0, 0, 0) 100%),
-				-webkit-linear-gradient(left, #FFF 0%, rgba(255, 255, 255, 0) 100%);
-	background: -ms-linear-gradient(bottom, #000 0%, rgba(0, 0, 0, 0) 100%),
-				-ms-linear-gradient(left, #FFF 0%, rgba(255, 255, 255, 0) 100%);
-	background: -o-linear-gradient(bottom, #000 0%, rgba(0, 0, 0, 0) 100%),
-				-o-linear-gradient(left, #FFF 0%, rgba(255, 255, 255, 0) 100%);
-
+	background: linear-gradient(to top, 
+    #000 0%, 
+    rgb(0 0 0 / 0) 100%),
+		linear-gradient(to right, 
+      #FFF 0%, 
+      rgb(255 255 255 / 0) 100%);
 	background-color: #F00;
 }
 
 /* HSL format - Hue-Saturation-Lightness */
 .ui-color-picker[data-mode='HSL'] .picking-area {
-	background: -moz-linear-gradient(top, hsl(0, 0%, 100%) 0%, hsla(0, 0%, 100%, 0) 50%,
-									hsla(0, 0%, 0%, 0) 50%, hsl(0, 0%, 0%) 100%),
-				-moz-linear-gradient(left, hsl(0, 0%, 50%) 0%, hsla(0, 0%, 50%, 0) 100%);
-	background: -webkit-linear-gradient(top, hsl(0, 0%, 100%) 0%, hsla(0, 0%, 100%, 0) 50%,
-									hsla(0, 0%, 0%, 0) 50%, hsl(0, 0%, 0%) 100%),
-				-webkit-linear-gradient(left, hsl(0, 0%, 50%) 0%, hsla(0, 0%, 50%, 0) 100%);
-	background: -ms-linear-gradient(top, hsl(0, 0%, 100%) 0%, hsla(0, 0%, 100%, 0) 50%,
-									hsla(0, 0%, 0%, 0) 50%, hsl(0, 0%, 0%) 100%),
-				-ms-linear-gradient(left, hsl(0, 0%, 50%) 0%, hsla(0, 0%, 50%, 0) 100%);
-	background: -o-linear-gradient(top, hsl(0, 0%, 100%) 0%, hsla(0, 0%, 100%, 0) 50%,
-									hsla(0, 0%, 0%, 0) 50%, hsl(0, 0%, 0%) 100%),
-				-o-linear-gradient(left, hsl(0, 0%, 50%) 0%, hsla(0, 0%, 50%, 0) 100%);
+	background: linear-gradient(to bottom,
+     hsl(0 0% 100%) 0%,
+     hsl(0 0% 100% / 0) 50%,
+		 hsl(0 0% 0% / 0) 50%,
+      hsl(0 0% 0%) 100%),
+		linear-gradient(to right, 
+      hsl(0 0% 50%) 0%, 
+      hsl(0 0% 50% / 0) 100%);
 	background-color: #F00;
 }
 
@@ -92,19 +81,15 @@
 
 .ui-color-picker .hue {
 	background: url("hue.png") center;
-	background: -moz-linear-gradient(left, #F00 0%, #FF0 16.66%, #0F0 33.33%, #0FF 50%,
-				#00F 66.66%, #F0F 83.33%, #F00 100%);
-	background: -webkit-linear-gradient(left, #F00 0%, #FF0 16.66%, #0F0 33.33%, #0FF 50%,
-				#00F 66.66%, #F0F 83.33%, #F00 100%);
-	background: -ms-linear-gradient(left, #F00 0%, #FF0 16.66%, #0F0 33.33%, #0FF 50%,
-				#00F 66.66%, #F0F 83.33%, #F00 100%);
-	background: -o-linear-gradient(left, #F00 0%, #FF0 16.66%, #0F0 33.33%, #0FF 50%,
-				#00F 66.66%, #F0F 83.33%, #F00 100%);
+	background: linear-gradient(to right, #F00, #FF0, #0F0, #0FF, #00F, #F0F, #F00);
 }
 
 .ui-color-picker .alpha {
 	border: 1px solid #CCC;
 	background: url("alpha.png");
+
+	background-image: conic-gradient(transparent 90deg, rgb(0 0 0 / 0.1) 90deg 180deg, transparent 180deg 270deg, rgb(0 0 0 / 0.1) 270deg);
+  background-size:  10px 10px;
 }
 
 .ui-color-picker .alpha-mask {
@@ -157,10 +142,7 @@
 	border: 1px solid #DDD;
 	text-align: center;
 	float: right;
-
-	-moz-user-select: text;
-	-webkit-user-select: text;
-	-ms-user-select: text;
+  user-select: text;
 }
 
 .ui-color-picker .input[data-topic="lightness"] {
@@ -202,8 +184,6 @@
 	width: 90px;
 	height: 24px;
 	padding: 2px 0;
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 }
 
@@ -233,7 +213,7 @@
 .ui-color-picker .preview-color {
 	width: 100%;
 	height: 100%;
-	background-color: rgba(255, 0, 0, 0.5);
+	background-color: rgb(255 0 0 0.5);
 	position: absolute;
 	z-index: 1;
 }
@@ -262,8 +242,6 @@
 
 .ui-input-slider {
 	height: 20px;
-	font-family: "Segoe UI", Arial, Helvetica, sans-serif;
-	-moz-user-select: none;
 	user-select: none;
 }
 
@@ -280,9 +258,6 @@
 	padding: 0;
 	width: 50px;
 	text-align: center;
-
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 }
 
@@ -332,18 +307,9 @@
 body {
 	max-width: 1000px;
 	margin: 0 auto;
-
 	font-family: "Segoe UI", Arial, Helvetica, sans-serif;
-
 	box-shadow: 0 0 5px 0 #999;
-
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
-
-	-moz-user-select: none;
-	-webkit-user-select: none;
-	-ms-user-select: none;
 	user-select: none;
 
 }
@@ -389,12 +355,9 @@ body {
  */
 #container {
 	width: 100%;
-
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
-
-	display: table;
+	display: grid;
+  grid-template-columns: 1fr;
 }
 
 /**
@@ -609,9 +572,6 @@ body {
 	position: absolute;
 	top: 10%;
 	left: 10%;
-
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 
 	transition: all 0.2s;
@@ -684,7 +644,6 @@ body {
 	width: 200px;
 	height: 100%;
 	padding: 0 10px;
-	font-family: "Segoe UI", Arial, Helvetica, sans-serif;
 	font-size: 16px;
 	color: #777;
 	text-align: center;
@@ -722,23 +681,13 @@ body {
  */
 
 #palette {
-	width: 1000px;
-	padding: 10px 0;
-	background-image: url('grain.png');
-	background-repeat: repeat;
+	display: grid;
+  grid-template-columns: auto auto;
 	background-color: #EEE;
 	color: #777;
-
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
-	box-sizing: border-box;
 }
 
 #color-palette {
-	width: 640px;
-	font-family: Arial, Helvetica, sans-serif;
-	color: #777;
-	float: left;
 }
 
 #color-palette .container {
@@ -855,7 +804,7 @@ body {
 
 	text-align: right;
 
-	border: 3px dashed rgb(221, 221, 221);
+	border: 3px dashed rgb(221 221 221);
 	border-radius: 15px;
 
 	position: absolute;
@@ -893,8 +842,8 @@ body {
 	min-width: 20px;
 	min-height: 20px;
 	position: absolute;
-	border: 1px solid rgba(255, 255, 255, 0.3);
-}
+	border: 1px solid rgb(255 255 255 / 0.3);
+} 
 
 #canvas .sample:hover {
 	cursor: move;


### PR DESCRIPTION
Updated CSS to remove unneeded prefixing.
Updated CSS and JS to RGB() and HSL() from legacy RGBA() and HSLA()
Renamed HSV to HWB
was going to convert to flex/grid, but that is for a different day (though did start)
