### PR TITLE
Adding semicolons after the last declarations

### DIFF
--- a/learn/selectors/after-icon.html
+++ b/learn/selectors/after-icon.html
@@ -11,7 +11,7 @@
 
     <style class="editable">
     .box::after {
-        content: " ➥"
+        content: " ➥";
     }
         
     </style>
@@ -24,7 +24,7 @@
 
     <textarea class="playable playable-css" style="height: 80px;">
 .box::after {
-    content: " ➥"
+    content: " ➥";
 }   
     </textarea>
 

--- a/learn/selectors/before.html
+++ b/learn/selectors/before.html
@@ -11,7 +11,7 @@
 
     <style class="editable">
     .box::before {
-        content: "This should show before the other content."
+        content: "This should show before the other content. ";
     }
         
     </style>
@@ -24,7 +24,7 @@
 
     <textarea class="playable playable-css" style="height: 80px;">
 .box::before {
-    content: "This should show before the other content."
+    content: "This should show before the other content. ";
 }   
     </textarea>
 


### PR DESCRIPTION
This PR adds semicolons after the last declarations appeared on [Pseudo-classes and pseudo-elements](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements#generating_content_with_before_and_after) in order to eliminate possible distraction for learners with resprect to the CSS syntax.

Fixes https://github.com/mdn/content/issues/25274.

*Note:* It seems that the GitHub website editor also did something to the ends of the changed files. Do I have to patch them up?