### PR TITLE
Adding missing `}` in the filter functions demo

### DIFF
--- a/types/filterfunctions.html
+++ b/types/filterfunctions.html
@@ -123,6 +123,7 @@
             break;
           default:
             console.error("Unknown filter set");
+        }
       }
 
       function setDiv(filter) {


### PR DESCRIPTION
This PR adds a missing `}` in the filter functions demo [code](https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function#examples).

Fixes https://github.com/mdn/content/issues/24874.