### PR TITLE
Update child.html

### DIFF
--- a/learn/selectors/child.html
+++ b/learn/selectors/child.html
@@ -11,7 +11,7 @@
 
     <style class="editable">
     ul > li {
-        border-top: 5px solid red;
+        color: red;
     }
         
     </style>
@@ -21,30 +21,28 @@
     <section class="preview">
     <ul>
         <li>Unordered item</li>
-        <li>Unordered item
-            <ol>
-                <li>Item 1</li>
-                <li>Item 2</li>
-            </ol>
-        </li>
+        <li>Unordered item</li>
+        <ol>
+            <li>Item 1</li>
+            <li>Item 2</li>
+        </ol>
     </ul>
     </section>
 
     <textarea class="playable playable-css" style="height: 80px;">
 ul > li {
-    border-top: 5px solid red;
+    color: red;
 }  
     </textarea>
 
     <textarea class="playable playable-html" style="height: 160px;">
 <ul>
     <li>Unordered item</li>
-    <li>Unordered item
-        <ol>
-            <li>Item 1</li>
-            <li>Item 2</li>
-        </ol>
-    </li>
+    <li>Unordered item</li>
+    <ol>
+        <li>Item 1</li>
+        <li>Item 2</li>
+    </ol>
 </ul>
     </textarea>
 


### PR DESCRIPTION
The example could be improved.  While fiddling with the 'border-top' field, changing it to 'border-left' or 'border-right' created a border that ran past ALL four link fields instead of just the first two.  Changing it to 'border-bottom' created a border under the first and fourth link fields.  Changing 'border-top: 5px solid red;' to a simple 'color: red;' resulted in ALL four links turning red.  This is because the '\<ol\>' section is within the second '\<li\>' field, which itself is a direct child of '\<ul\>'.  

I think a better example would not have the '\<ol\>' section nested within the second link, but rather nested within the '\<ul\>' section itself; and use a simple 'color: red;' styling.  Then, removing the '>' demonstrates child combinator vs descendant combinator.  And fiddling is simplified.

If this commit is accepted, slight changes will also be needed to the text in:
'en-US/docs/Learn/CSS/Building_blocks/Selectors/Combinators'