### PR TITLE
Add the `space` value to the options of `border-image-repeat`

### DIFF
--- a/tools/border-image-generator/index.html
+++ b/tools/border-image-generator/index.html
@@ -88,18 +88,20 @@
               <div class="title"> additional-properties </div>
               <div class="property">
                   <div class="name"> repeat-x </div>
-                  <div class="ui-dropdown border-repeat" data-topic="image-repeat-X" data-selected="2">
-                      <div data-value="0">repeat</div>
+                  <div class="ui-dropdown border-repeat" data-topic="image-repeat-X" data-selected="1">
                       <div data-value="0">stretch</div>
+                      <div data-value="0">repeat</div>
                       <div data-value="0">round</div>
+                      <div data-value="0">space</div>
                   </div>
               </div>
               <div class="property">
                   <div class="name"> repeat-y </div>
-                  <div class="ui-dropdown border-repeat" data-topic="image-repeat-Y" data-selected="2">
-                      <div data-value="1">repeat</div>
+                  <div class="ui-dropdown border-repeat" data-topic="image-repeat-Y" data-selected="1">
                       <div data-value="1">stretch</div>
+                      <div data-value="1">repeat</div>
                       <div data-value="1">round</div>
+                      <div data-value="1">space</div>
                   </div>
               </div>
               <div class="property">

--- a/tools/border-image-generator/styles.css
+++ b/tools/border-image-generator/styles.css
@@ -843,7 +843,7 @@ body[data-move='Y'] {
 }
 
 #controls .border-repeat .ui-dropdown-list {
-	height: 6.2em;
+	height: 8.2em;
 	border-width: 1px;
 	text-align: center;
 }


### PR DESCRIPTION
Fixes #79.

This PR also aligns the order of values of `border-image-repeat` to [that](https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-repeat) in the spec.