### PR TITLE
Fixed typo in <title> element

### DIFF
--- a/learn/tasks/backgrounds/backgrounds2-download.html
+++ b/learn/tasks/backgrounds/backgrounds2-download.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
-    <title>Backgrounds and Borders: Task 1</title>
+    <title>Backgrounds and Borders: Task 2</title>
     <style>
       body {
         background-color: #fff;


### PR DESCRIPTION
Changed <title> to say:
Backgrounds and Borders: Task 2

It is the second task during "Test your skills: background and borders".  The typo made me double-check that I had the right file downloaded.