### PR TITLE
Fix `repeat` for predefined samples

### DIFF
--- a/tools/border-image-generator/script.js
+++ b/tools/border-image-generator/script.js
@@ -692,7 +692,7 @@ var BorderImage = (function BorderImage() {
 			width_units		: [0, 0, 0, 0],
 			outset_units	: [0, 0, 0, 0],
 
-			repeat			: [1, 1],
+			repeat			: [0, 0],
 			size			: [300, 200],
 			preview_area	: 400
 		};
@@ -740,7 +740,7 @@ var BorderImage = (function BorderImage() {
 			width_units		: [0, 0, 0, 0],
 			outset_units	: [0, 0, 0, 0],
 
-			repeat			: [0, 0],
+			repeat			: [1, 1],
 			size			: [300, 200],
 			preview_area	: 400
 		};
@@ -756,7 +756,7 @@ var BorderImage = (function BorderImage() {
 			width_units		: [0, 0, 0, 0],
 			outset_units	: [0, 0, 0, 0],
 
-			repeat			: [0, 0],
+			repeat			: [1, 1],
 			size			: [300, 200],
 			preview_area	: 400,
 		};


### PR DESCRIPTION
This PR fixes the `repeat` values for the predefined samples in the border-image generator. The old values became mismatched after #129.