### PR TITLE
Fixed incorrect conversion to HWB

### DIFF
--- a/modules/colors.html
+++ b/modules/colors.html
@@ -189,9 +189,9 @@
 
       function createHWB(h, s, l, opacity) {
         const cell = document.querySelector("#HWB td");
-        const hsv = (s * ((l < 50) ? l : 100 - l)) / 100;
-        let W = (hsv === 0) ? 0 : ((2 * hsv) / (l + hsv)) * 100;
-        let B = l + hsv;
+        const chroma = s * (1 - Math.abs(l/50 - 1));
+        let W = l - chroma / 2;
+        let B = 100 - l - chroma / 2;
         W = W.toFixed(1);
         B = B.toFixed(1);
         if (opacity === 1) {


### PR DESCRIPTION
The demo on https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Colors produces wrong results for the HWB colour model. For example, selecting black yields `hwb(0 0.0% 0.0%)`, which is actually red. The correct result is `hwb(0 0.0% 100.0%)`. Similarly, selecting a white colour yields the code for black, whereas a red colour results in `hwb(0 100.0% 100.0%)`. The white and black mixins should be zero, and in any case sum to at most 100%.

I did not understand where the formulas for W and B could have come from. The value called `hsv` in the original is one half the chroma value. I replaced it for the sake of better understanding.