### PR TITLE
Fix 26970

### DIFF
--- a/flexbox/use-cases/media-flipped.html
+++ b/flexbox/use-cases/media-flipped.html
@@ -1,105 +1,104 @@
 <!DOCTYPE html>
 <html lang="en-us">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width" />
-  <title>Use cases: media objects</title>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Use cases: media objects</title>
 
-  <style>
-    body {
-      font: 1.2em Helvetica, Arial, sans-serif;
-      margin: 20px;
-      padding: 0;
-    }
+    <style>
+      body {
+        font: 1.2em Helvetica, Arial, sans-serif;
+        margin: 20px;
+        padding: 0;
+      }
 
-    textarea {
-      font-family: monospace;
-      display: block;
-      margin-bottom: 10px;
-      background-color: #F4F7F8;
-      border: none;
-      border-left: 6px solid #558ABB;
-      color: #4D4E53;
-      width: 90%;
-      max-width: 700px;
-      padding: 10px 10px 0px;
-      font-size: 90%;
-    }
+      textarea {
+        font-family: monospace;
+        display: block;
+        margin-bottom: 10px;
+        background-color: #f4f7f8;
+        border: none;
+        border-left: 6px solid #558abb;
+        color: #4d4e53;
+        width: 90%;
+        max-width: 700px;
+        padding: 10px 10px 0px;
+        font-size: 90%;
+      }
 
-    textarea:nth-of-type(1) {
-      height: 250px
-    }
+      textarea:nth-of-type(1) {
+        height: 250px;
+      }
 
-    textarea:nth-of-type(2) {
-      height: 180px
-    }
+      textarea:nth-of-type(2) {
+        height: 180px;
+      }
 
-    .playable-buttons {
-      text-align: right;
-      width: 90%;
-      max-width: 700px;
-      padding: 5px 10px 5px 26px;
-      font-size: 100%;
-    }
+      .playable-buttons {
+        text-align: right;
+        width: 90%;
+        max-width: 700px;
+        padding: 5px 10px 5px 26px;
+        font-size: 100%;
+      }
 
-    section {
-      width: 90%;
-      max-width: 700px;
-      border: 1px solid #4D4E53;
-      border-radius: 2px;
-      padding: 10px 14px 10px 10px;
-      margin-bottom: 10px;
-    }
+      section {
+        width: 90%;
+        max-width: 700px;
+        border: 1px solid #4d4e53;
+        border-radius: 2px;
+        padding: 10px 14px 10px 10px;
+        margin-bottom: 10px;
+      }
 
-    section input {
-      display: block;
-      margin: 5px;
-    }
+      section input {
+        display: block;
+        margin: 5px;
+      }
 
-    img {
-      max-width: 100%;
-    }
+      img {
+        max-width: 100%;
+      }
 
-    .media {
-      width: 500px;
-      border: 2px dotted rgb(96, 139, 168);
-    }
+      .media {
+        width: 500px;
+        border: 2px dotted rgb(96, 139, 168);
+      }
 
-    .media img {
+      .media img {
         margin: 0 10px 0 0;
-    }
+      }
 
-    .media.flipped img {
+      .media.flipped img {
         margin: 0 0 0 10px;
-    }
-
-
-
-  </style>
-  <style class="editable">
-    .media {
-      display: flex;
-      align-items: flex-start;
-    }
-    .media.flipped {
+      }
+    </style>
+    <style class="editable">
+      .media {
+        display: flex;
+        align-items: flex-start;
+      }
+      .media.flipped {
         flex-direction: row-reverse;
-    }
-    .media .content {
+      }
+      .media .content {
         flex: 1;
         padding: 10px;
-    }
-  </style>
-</head>
+      }
+    </style>
+  </head>
 
-<body>
-  <section>
-    <div class="media flipped">
-      <div class="image"><img src="MDN.svg" alt="MDN logo"></div>
-      <div class="content">This is the content of my media object. Items directly inside the flex container will be aligned to flex-start.</div>
-    </div>
-
-  </section>
-  <textarea class="playable-css">
+  <body>
+    <section>
+      <div class="media flipped">
+        <div class="image"><img src="MDN.svg" alt="MDN logo" /></div>
+        <div class="content">
+          This is the content of my media object. Items directly inside the flex
+          container will be aligned to flex-start.
+        </div>
+      </div>
+    </section>
+    <textarea class="playable-css">
 .media {
   display: flex;
   align-items: flex-start;
@@ -113,40 +112,41 @@
   flex: 1;
   padding: 10px;
 }
-</textarea>
-  <textarea id="code" class="playable-html">
+</textarea
+    >
+    <textarea id="code" class="playable-html">
 <div class="media flipped">
   <div class="image"><img src="MDN.svg" alt="MDN logo"></div>
     <div class="content">This is the content of my media object. Items directly inside the flex container will be aligned to flex-start.</div>
 </div>
-</textarea>
-  <div class="playable-buttons">
-    <input id="reset" type="button" value="Reset">
-  </div>
-</body>
-<script>
-  var section = document.querySelector('section');
-  var editable = document.querySelector('.editable');
-  var textareaHTML = document.querySelector('.playable-html');
-  var textareaCSS = document.querySelector('.playable-css');
-  var reset = document.getElementById('reset');
-  var htmlCode = textareaHTML.value;
-  var cssCode = textareaCSS.value;
+</textarea
+    >
+    <div class="playable-buttons">
+      <input id="reset" type="button" value="Reset" />
+    </div>
+  </body>
+  <script>
+    var section = document.querySelector("section");
+    var editable = document.querySelector(".editable");
+    var textareaHTML = document.querySelector(".playable-html");
+    var textareaCSS = document.querySelector(".playable-css");
+    var reset = document.getElementById("reset");
+    var htmlCode = textareaHTML.value;
+    var cssCode = textareaCSS.value;
 
-  function fillCode() {
-    editable.innerHTML = textareaCSS.value;
-    section.innerHTML = textareaHTML.value;
-  }
+    function fillCode() {
+      editable.innerHTML = textareaCSS.value;
+      section.innerHTML = textareaHTML.value;
+    }
 
-  reset.addEventListener('click', function () {
-    textareaHTML.value = htmlCode;
-    textareaCSS.value = cssCode;
-    fillCode();
-  });
+    reset.addEventListener("click", function () {
+      textareaHTML.value = htmlCode;
+      textareaCSS.value = cssCode;
+      fillCode();
+    });
 
-  textareaHTML.addEventListener('input', fillCode);
-  textareaCSS.addEventListener('input', fillCode);
-  window.addEventListener('load', fillCode);
-</script>
-
+    textareaHTML.addEventListener("input", fillCode);
+    textareaCSS.addEventListener("input", fillCode);
+    window.addEventListener("load", fillCode);
+  </script>
 </html>

--- a/flexbox/use-cases/media-flipped.html
+++ b/flexbox/use-cases/media-flipped.html
@@ -27,7 +27,7 @@
       }
 
       textarea:nth-of-type(1) {
-        height: 250px;
+        height: 310px;
       }
 
       textarea:nth-of-type(2) {
@@ -56,10 +56,6 @@
         margin: 5px;
       }
 
-      img {
-        max-width: 100%;
-      }
-
       .media {
         width: 500px;
         border: 2px dotted rgb(96, 139, 168);
@@ -74,6 +70,9 @@
       }
     </style>
     <style class="editable">
+      img {
+        max-width: 100%;
+      }
       .media {
         display: flex;
         align-items: flex-start;
@@ -99,6 +98,10 @@
       </div>
     </section>
     <textarea class="playable-css">
+img {
+  max-width: 100%;
+}
+
 .media {
   display: flex;
   align-items: flex-start;

--- a/flexbox/use-cases/media.html
+++ b/flexbox/use-cases/media.html
@@ -1,97 +1,97 @@
 <!DOCTYPE html>
 <html lang="en-us">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width" />
-  <title>Use cases: media objects</title>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Use cases: media objects</title>
 
-  <style>
-    body {
-      font: 1.2em Helvetica, Arial, sans-serif;
-      margin: 20px;
-      padding: 0;
-    }
+    <style>
+      body {
+        font: 1.2em Helvetica, Arial, sans-serif;
+        margin: 20px;
+        padding: 0;
+      }
 
-    textarea {
-      font-family: monospace;
-      display: block;
-      margin-bottom: 10px;
-      background-color: #F4F7F8;
-      border: none;
-      border-left: 6px solid #558ABB;
-      color: #4D4E53;
-      width: 90%;
-      max-width: 700px;
-      padding: 10px 10px 0px;
-      font-size: 90%;
-    }
+      textarea {
+        font-family: monospace;
+        display: block;
+        margin-bottom: 10px;
+        background-color: #f4f7f8;
+        border: none;
+        border-left: 6px solid #558abb;
+        color: #4d4e53;
+        width: 90%;
+        max-width: 700px;
+        padding: 10px 10px 0px;
+        font-size: 90%;
+      }
 
-    textarea:nth-of-type(1) {
-      height: 180px
-    }
+      textarea:nth-of-type(1) {
+        height: 180px;
+      }
 
-    textarea:nth-of-type(2) {
-      height: 180px
-    }
+      textarea:nth-of-type(2) {
+        height: 180px;
+      }
 
-    .playable-buttons {
-      text-align: right;
-      width: 90%;
-      max-width: 700px;
-      padding: 5px 10px 5px 26px;
-      font-size: 100%;
-    }
+      .playable-buttons {
+        text-align: right;
+        width: 90%;
+        max-width: 700px;
+        padding: 5px 10px 5px 26px;
+        font-size: 100%;
+      }
 
-    section {
-      width: 90%;
-      max-width: 700px;
-      border: 1px solid #4D4E53;
-      border-radius: 2px;
-      padding: 10px 14px 10px 10px;
-      margin-bottom: 10px;
-    }
+      section {
+        width: 90%;
+        max-width: 700px;
+        border: 1px solid #4d4e53;
+        border-radius: 2px;
+        padding: 10px 14px 10px 10px;
+        margin-bottom: 10px;
+      }
 
-    section input {
-      display: block;
-      margin: 5px;
-    }
+      section input {
+        display: block;
+        margin: 5px;
+      }
 
-    img {
-      max-width: 100%;
-    }
+      img {
+        max-width: 100%;
+      }
 
-    .media {
-      width: 500px;
-      border: 2px dotted rgb(96, 139, 168);
-    }
+      .media {
+        width: 500px;
+        border: 2px dotted rgb(96, 139, 168);
+      }
 
-    .media .image {
+      .media .image {
         margin: 0 10px 0 0;
-    }
-
-
-  </style>
-  <style class="editable">
-    .media {
-      display: flex;
-      align-items: flex-start;
-    }
-    .media .content {
+      }
+    </style>
+    <style class="editable">
+      .media {
+        display: flex;
+        align-items: flex-start;
+      }
+      .media .content {
         flex: 1;
         padding: 10px;
-    }
-  </style>
-</head>
+      }
+    </style>
+  </head>
 
-<body>
-  <section>
-    <div class="media">
-      <div class="image"><img src="MDN.svg" alt="MDN logo"></div>
-      <div class="content">This is the content of my media object. Items directly inside the flex container will be aligned to flex-start.</div>
-    </div>
-
-  </section>
-  <textarea class="playable-css">
+  <body>
+    <section>
+      <div class="media">
+        <div class="image"><img src="MDN.svg" alt="MDN logo" /></div>
+        <div class="content">
+          This is the content of my media object. Items directly inside the flex
+          container will be aligned to flex-start.
+        </div>
+      </div>
+    </section>
+    <textarea class="playable-css">
 .media {
   display: flex;
   align-items: flex-start;
@@ -101,40 +101,41 @@
   flex: 1;
   padding: 10px;
 }
-</textarea>
-  <textarea id="code" class="playable-html">
+</textarea
+    >
+    <textarea id="code" class="playable-html">
 <div class="media">
   <div class="image"><img src="MDN.svg" alt="MDN logo"></div>
     <div class="content">This is the content of my media object. Items directly inside the flex container will be aligned to flex-start.</div>
 </div>
-</textarea>
-  <div class="playable-buttons">
-    <input id="reset" type="button" value="Reset">
-  </div>
-</body>
-<script>
-  var section = document.querySelector('section');
-  var editable = document.querySelector('.editable');
-  var textareaHTML = document.querySelector('.playable-html');
-  var textareaCSS = document.querySelector('.playable-css');
-  var reset = document.getElementById('reset');
-  var htmlCode = textareaHTML.value;
-  var cssCode = textareaCSS.value;
+</textarea
+    >
+    <div class="playable-buttons">
+      <input id="reset" type="button" value="Reset" />
+    </div>
+  </body>
+  <script>
+    var section = document.querySelector("section");
+    var editable = document.querySelector(".editable");
+    var textareaHTML = document.querySelector(".playable-html");
+    var textareaCSS = document.querySelector(".playable-css");
+    var reset = document.getElementById("reset");
+    var htmlCode = textareaHTML.value;
+    var cssCode = textareaCSS.value;
 
-  function fillCode() {
-    editable.innerHTML = textareaCSS.value;
-    section.innerHTML = textareaHTML.value;
-  }
+    function fillCode() {
+      editable.innerHTML = textareaCSS.value;
+      section.innerHTML = textareaHTML.value;
+    }
 
-  reset.addEventListener('click', function () {
-    textareaHTML.value = htmlCode;
-    textareaCSS.value = cssCode;
-    fillCode();
-  });
+    reset.addEventListener("click", function () {
+      textareaHTML.value = htmlCode;
+      textareaCSS.value = cssCode;
+      fillCode();
+    });
 
-  textareaHTML.addEventListener('input', fillCode);
-  textareaCSS.addEventListener('input', fillCode);
-  window.addEventListener('load', fillCode);
-</script>
-
+    textareaHTML.addEventListener("input", fillCode);
+    textareaCSS.addEventListener("input", fillCode);
+    window.addEventListener("load", fillCode);
+  </script>
 </html>

--- a/flexbox/use-cases/media.html
+++ b/flexbox/use-cases/media.html
@@ -27,7 +27,7 @@
       }
 
       textarea:nth-of-type(1) {
-        height: 180px;
+        height: 240px;
       }
 
       textarea:nth-of-type(2) {
@@ -56,10 +56,6 @@
         margin: 5px;
       }
 
-      img {
-        max-width: 100%;
-      }
-
       .media {
         width: 500px;
         border: 2px dotted rgb(96, 139, 168);
@@ -70,6 +66,9 @@
       }
     </style>
     <style class="editable">
+      img {
+        max-width: 100%;
+      }
       .media {
         display: flex;
         align-items: flex-start;
@@ -92,6 +91,10 @@
       </div>
     </section>
     <textarea class="playable-css">
+img {
+  max-width: 100%;
+}
+
 .media {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/26970, by making the `img {max-width: 100%;}` rule visible in the editor.

Because this PR does Prettier reformatting, it's in 2 commits:
- https://github.com/mdn/css-examples/pull/139/commits/9d68975bebd29209927145b412c3f3bb9c1ccea2: Prettier
- https://github.com/mdn/css-examples/pull/139/commits/e65d3f5efa2640da683a0d745582eb75b41a2728: substantive changes
