### PR TITLE
fix: use `gap` instead of margin for flex navigation

### DIFF
--- a/flexbox/use-cases/split-navigation.html
+++ b/flexbox/use-cases/split-navigation.html
@@ -79,15 +79,12 @@
   </style>
   <style class="editable">
     nav ul {
-        display: flex;
-        margin: 0 -10px;
-      }
-    nav li {
-        margin: 0 10px;
+      display: flex;
+      gap: 20px;
     }
-      .push-right {
-          margin-left: auto;
-      }
+    .push-right {
+      margin-left: auto;
+    }
   </style>
 </head>
 
@@ -107,11 +104,7 @@
   <textarea class="playable-css">
 nav ul {
   display: flex;
-  margin: 0 -10px;
-}
-
-nav li {
-  margin: 0 10px;
+  gap: 20px;
 }
 
 .push-right {


### PR DESCRIPTION
- Fixes https://github.com/mdn/content/issues/13591
