### PR TITLE
Update image-set-type.html

### DIFF
--- a/images/image-set-type.html
+++ b/images/image-set-type.html
@@ -16,12 +16,13 @@
 
     <style class="editable">
        .box {
-          background-image: -webkit-image-set(
-            url("large-balloons.avif"),
-            url("large-balloons.jpg"));
           background-image: image-set(
             url("large-balloons.avif") type("image/avif"),
             url("large-balloons.jpg") type("image/jpeg"));
+          background-image: -webkit-image-set(
+            url("large-balloons.avif"),
+            url("large-balloons.jpg"));
+          
         }
     </style>
 </head>
@@ -33,12 +34,13 @@
 
     <textarea class="playable playable-css" style="height: 155px;">
 .box {
-  background-image: -webkit-image-set(
-    url("large-balloons.avif"),
-    url("large-balloons.jpg"));
   background-image: image-set(
     url("large-balloons.avif") type("image/avif"),
     url("large-balloons.jpg") type("image/jpeg"));
+  background-image: -webkit-image-set(
+    url("large-balloons.avif"),
+    url("large-balloons.jpg"));
+  
 }
     </textarea>
 


### PR DESCRIPTION
Placing the `-web-kit-image-set` before the `image-set` causes Firefox and Chrome to given an 'invalid property value' to `-web-kit-image-set` definition and the `image-set` that follows it.