### PR TITLE
Update grid auto placement example

### DIFF
--- a/grid/docs/autoplacement.html
+++ b/grid/docs/autoplacement.html
@@ -30,7 +30,7 @@
     <style class="editable">
       .wrapper {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+        grid-template-columns: repeat(3, minmax(120px, 1fr));
         gap: 10px;
         grid-auto-flow: dense;
       }
@@ -48,8 +48,6 @@
             <li class="landscape"><img src="landscape.jpg" alt="placeholder"></li>
             <li class="landscape"><img src="landscape.jpg" alt="placeholder"></li>
             <li class="landscape"><img src="landscape.jpg" alt="placeholder"></li>
-            <li><img src="portrait.jpg" alt="placeholder"></li>
-            <li><img src="portrait.jpg" alt="placeholder"></li>
             <li class="landscape"><img src="landscape.jpg" alt="placeholder"></li>
             <li><img src="portrait.jpg" alt="placeholder"></li>
             <li><img src="portrait.jpg" alt="placeholder"></li>
@@ -60,7 +58,7 @@
     <textarea class="playable playable-css" style="height: 200px;">
 .wrapper {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  grid-template-columns: repeat(3, minmax(120px, 1fr));
   gap: 10px;
   grid-auto-flow: dense;
 }
@@ -72,13 +70,10 @@
 
     <textarea class="playable playable-html" style="height: 300px;">
 <ul class="wrapper">
-    <li><img src="./portrait.jpg" alt="placeholder"></li>
-    <li class="landscape"><img src="landscape.jpg" alt="placeholder"></li>
     <li><img src="portrait.jpg" alt="placeholder"></li>
     <li class="landscape"><img src="landscape.jpg" alt="placeholder"></li>
     <li class="landscape"><img src="landscape.jpg" alt="placeholder"></li>
-    <li><img src="portrait.jpg" alt="placeholder"></li>
-    <li><img src="portrait.jpg" alt="placeholder"></li>
+    <li class="landscape"><img src="landscape.jpg" alt="placeholder"></li>
     <li class="landscape"><img src="landscape.jpg" alt="placeholder"></li>
     <li><img src="portrait.jpg" alt="placeholder"></li>
     <li><img src="portrait.jpg" alt="placeholder"></li>


### PR DESCRIPTION
Fixes:
- https://github.com/mdn/css-examples/issues/66
- https://github.com/mdn/content/issues/13721

## Problem

There are no gaps in the grid without using `dense` algorithm. So removing the `grid-auto-flow: dense` line has no effect.

## Solution

Interleaving big and small blocks is not helping here. Putting bigger blocks together creates noticeable amount of gaps.