### PR TITLE
fix(CSS): too much overflow in the example output

### DIFF
--- a/learn/overflow/auto.html
+++ b/learn/overflow/auto.html
@@ -11,7 +11,7 @@
     <style class="editable">
       .box {
         border: 1px solid #333333;
-        width: 200px;
+        width: 350px;
         height: 100px;
         overflow: auto;
       }
@@ -26,7 +26,7 @@
     <textarea class="playable playable-css" style="height: 120px;">
 .box {
   border: 1px solid #333333;
-  width: 200px;
+  width: 350px;
   height: 100px;
   overflow: auto;
 }

--- a/learn/overflow/block-overflow.html
+++ b/learn/overflow/block-overflow.html
@@ -11,7 +11,7 @@
     <style class="editable">
       .box {
         border: 1px solid #333333;
-        width: 200px;
+        width: 350px;
         height: 100px;
       }
     </style>
@@ -25,7 +25,7 @@
     <textarea class="playable playable-css" style="height: 120px;">
 .box {
   border: 1px solid #333333;
-  width: 200px;
+  width: 350px;
   height: 100px;
 }
     </textarea>

--- a/learn/overflow/hidden.html
+++ b/learn/overflow/hidden.html
@@ -11,7 +11,7 @@
     <style class="editable">
       .box {
         border: 1px solid #333333;
-        width: 200px;
+        width: 350px;
         height: 100px;
         overflow: hidden;
       }
@@ -26,7 +26,7 @@
     <textarea class="playable playable-css" style="height: 120px;">
 .box {
   border: 1px solid #333333;
-  width: 200px;
+  width: 350px;
   height: 100px;
   overflow: hidden;
 }

--- a/learn/overflow/scroll-y.html
+++ b/learn/overflow/scroll-y.html
@@ -11,7 +11,7 @@
     <style class="editable">
       .box {
         border: 1px solid #333333;
-        width: 200px;
+        width: 350px;
         height: 100px;
         overflow-y: scroll;
       }
@@ -26,7 +26,7 @@
     <textarea class="playable playable-css" style="height: 120px;">
 .box {
   border: 1px solid #333333;
-  width: 200px;
+  width: 350px;
   height: 100px;
   overflow-y: scroll;
 }

--- a/learn/overflow/scroll.html
+++ b/learn/overflow/scroll.html
@@ -11,7 +11,7 @@
     <style class="editable">
       .box {
         border: 1px solid #333333;
-        width: 200px;
+        width: 350px;
         height: 100px;
         overflow: scroll;
       }
@@ -26,7 +26,7 @@
     <textarea class="playable playable-css" style="height: 120px;">
 .box {
   border: 1px solid #333333;
-  width: 200px;
+  width: 350px;
   height: 100px;
   overflow: scroll;
 }


### PR DESCRIPTION
- Fixes https://github.com/mdn/content/issues/27975

If we update width we won't have to update `mdn/content` side. With width `350px` the overflow doesn't spill over the output area.

To test the change try the width in the live sample https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Overflowing_content#css_tries_to_avoid_data_loss