### PR TITLE
Fix content issue 28901

### DIFF
--- a/learn/tasks/sizing/height-min-height-download.html
+++ b/learn/tasks/sizing/height-min-height-download.html
@@ -19,10 +19,6 @@
         margin-bottom: 1em;
       }
 
-      .preview {
-        min-height: 400px;
-      }
-
       .box1 {
       }
 

--- a/learn/tasks/sizing/height-min-height-download.html
+++ b/learn/tasks/sizing/height-min-height-download.html
@@ -5,45 +5,47 @@
     <title>Sizing Task 1: height and min-height</title>
 
     <style>
-    body {
-      background-color: #fff;
-      color: #333;
-      font: 1.2em / 1.5 Helvetica Neue, Helvetica, Arial, sans-serif;
-      padding: 1em;
-      margin: 0;
-    }
+      body {
+        background-color: #fff;
+        color: #333;
+        font: 1.2em / 1.5 Helvetica Neue, Helvetica, Arial, sans-serif;
+        padding: 1em;
+        margin: 0;
+      }
 
-    .box {
-      border: 5px solid #000;
-      width: 400px;
-      margin-bottom: 1em;
-    }
+      .box {
+        border: 5px solid #000;
+        width: 400px;
+        margin-bottom: 1em;
+      }
 
-    .preview {
-      min-height: 400px;
-    }
+      .preview {
+        min-height: 400px;
+      }
 
-    .box1 {
+      .box1 {
+      }
 
-    }
-
-    .box2 {
-
-    }
-
+      .box2 {
+      }
     </style>
   </head>
 
   <body>
-
     <div class="box box1">
-      <p>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic. Gumbo beet greens corn soko endive gumbo gourd. </p>
+      <p>
+        Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh
+        onion daikon amaranth tatsoi tomatillo melon azuki bean garlic. Gumbo
+        beet greens corn soko endive gumbo gourd.
+      </p>
     </div>
 
     <div class="box box2">
-      <p>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic. Gumbo beet greens corn soko endive gumbo gourd. </p>
+      <p>
+        Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh
+        onion daikon amaranth tatsoi tomatillo melon azuki bean garlic. Gumbo
+        beet greens corn soko endive gumbo gourd.
+      </p>
     </div>
-   
   </body>
-
 </html>


### PR DESCRIPTION
See https://github.com/mdn/content/issues/28901.

The substantive change here is to remove the `.preview` CSS rule, that's not relevant to the downloadable version of this example and that confused the reporter of https://github.com/mdn/content/issues/28901.

2 commits:
- https://github.com/mdn/css-examples/commit/e8c4e979b81fbfe38e05551f529f6f8c524c0022: Prettier formatting only
- https://github.com/mdn/css-examples/commit/09139b4117f8a2a2f7f319295e662be647f76f30: remove `.preview`