### PR TITLE
CSS Transforms Module Interactive Example

### DIFF
--- a/modules/transforms.html
+++ b/modules/transforms.html
@@ -6,40 +6,66 @@
     <meta name="viewport" content="width=device-width" />
     <title>CSS Transforms</title>
     <style>
-        #transformFieldset>div {
-            display: flex;
-            flex-direction: column;
-            align-items: start;
-        }
-
-        p {
-            margin: 0;
-        }
-
-        legend {
-            font-size: large;
-            font-weight: bold;
+        #allTransformFieldset {
+            border: none;
             padding: 0;
+            margin-bottom: 4px;
         }
 
-        #fieldsetContainer {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 8px;
+        #allTransformFieldset>legend {
+            margin-bottom: 4px;
         }
 
         fieldset {
             margin: 0;
         }
 
-        #cubeContainer {
+        legend {
+            font-weight: bold;
+            padding: 0;
+        }
+
+        #fieldsetSection {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: start;
+            gap: 8px;
+        }
+
+        #outputSection {
             width: 100%;
             min-height: 400px;
-            perspective: 200px;
             background: linear-gradient(skyblue, khaki);
             display: flex;
             justify-content: center;
             align-items: center;
+            position: relative;
+        }
+
+        #outputContainer {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            perspective: 200px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            transform-style: preserve-3d;
+        }
+
+        #z0 {
+            width: 50px;
+            height: 50px;
+            background: linear-gradient(to right bottom, rgb(223, 223, 223), rgb(190, 190, 190));
+            transform: translateZ(0px);
+            position: absolute;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 14px;
+            color: black;
+            border-radius: 100%;
+            outline: 1px solid rgba(0, 0, 0, 0.35);
         }
 
         #cube {
@@ -47,6 +73,8 @@
             height: 100px;
             transform-style: preserve-3d;
             transition: all 0.075s ease-out;
+            pointer-events: none;
+            position: absolute;
         }
 
         .face {
@@ -92,25 +120,60 @@
             transform: rotateX(-90deg) translateZ(50px);
         }
 
-        fieldset,
-        fieldset>div {
+        .transformFieldset {
+            margin: 0;
+        }
+
+        .controlsContainer {
             display: flex;
             flex-direction: column;
             align-items: start;
             gap: 4px;
         }
 
-        fieldset>div>div,
-        fieldset>div>div>label {
+        .controlsContainer {
+            width: 100%;
+        }
+
+        .controlsContainer>div {
             display: flex;
             flex-direction: row;
             align-items: center;
             gap: 4px;
         }
 
-        fieldset>div>div>label>span {
+        @supports selector(:has(*)) {
+
+            .showCheckbox,
+            label:has(input.showCheckbox) {
+                cursor: pointer;
+            }
+
+            .transformFieldset>div {
+                display: none;
+            }
+
+            .transformFieldset:has(>legend>label>input.showCheckbox:checked)>div {
+                display: block;
+            }
+        }
+
+        @supports not selector(:has(*)) {
+            .showCheckbox {
+                display: none;
+            }
+        }
+
+        .controlsContainer>div>label {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .controlsContainer>div>label>span {
             width: 12px;
-            font-size: large;
+            font-weight: bold;
         }
 
         #resetAllButton,
@@ -135,16 +198,20 @@
 
 <body>
     <article>
-        <fieldset id="transformFieldset">
+        <fieldset id="allTransformFieldset">
             <legend>Transform settings
                 <button id="resetAllButton" aria-label="Reset">↻</button>
             </legend>
-            <section id="fieldsetContainer">
-                <fieldset>
-                    <legend>Translation (px)
+            <section id="fieldsetSection">
+                <fieldset class="transformFieldset">
+                    <legend>
+                        <label>
+                            <input class="showCheckbox" type="checkbox" checked />
+                            <span>Translation (px)</span>
+                        </label>
                         <button id="translateSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
                     </legend>
-                    <div>
+                    <div class="controlsContainer">
                         <div>
                             <label>
                                 <span>X</span>
@@ -172,11 +239,15 @@
                     </div>
                 </fieldset>
 
-                <fieldset>
-                    <legend>Rotation (deg)
+                <fieldset class="transformFieldset">
+                    <legend>
+                        <label>
+                            <input class="showCheckbox" type="checkbox" />
+                            <span>Rotation (deg)</span>
+                        </label>
                         <button id="rotateSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
                     </legend>
-                    <div>
+                    <div class="controlsContainer">
                         <div>
                             <label>
                                 <span>X</span>
@@ -204,11 +275,15 @@
                     </div>
                 </fieldset>
 
-                <fieldset>
-                    <legend>Scale (factor)
+                <fieldset class="transformFieldset">
+                    <legend>
+                        <label>
+                            <input class="showCheckbox" type="checkbox" />
+                            <span>Scale (factor)</span>
+                        </label>
                         <button id="scaleSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
                     </legend>
-                    <div>
+                    <div class="controlsContainer">
                         <div>
                             <label>
                                 <span>X</span>
@@ -236,11 +311,15 @@
                     </div>
                 </fieldset>
 
-                <fieldset>
-                    <legend>Skew (deg)
+                <fieldset class="transformFieldset">
+                    <legend>
+                        <label>
+                            <input class="showCheckbox" type="checkbox" />
+                            <span>Skew (deg)</span>
+                        </label>
                         <button id="skewSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
                     </legend>
-                    <div>
+                    <div class="controlsContainer">
                         <div>
                             <label>
                                 <span>X</span>
@@ -261,56 +340,55 @@
                 </fieldset>
             </section>
         </fieldset>
-        <section id="cubeContainer">
-            <div id="cube">
-                <div class="face front">1</div>
-                <div class="face back">2</div>
-                <div class="face right">3</div>
-                <div class="face left">4</div>
-                <div class="face top">5</div>
-                <div class="face bottom">6</div>
+        <section id="outputSection">
+            <div id="outputContainer">
+                <div id="cube">
+                    <div class="face front">1</div>
+                    <div class="face back">2</div>
+                    <div class="face right">3</div>
+                    <div class="face left">4</div>
+                    <div class="face top">5</div>
+                    <div class="face bottom">6</div>
+                </div>
+                <div id="z0"><code>z:0px</code></div>
             </div>
         </section>
     </article>
     <script>
-        const cube = document.querySelector("#cube");
-
-        const transformFieldset = document.querySelector("#transformFieldset");
-
-        transformFieldset.querySelectorAll("input[type='range']").forEach((rangeInput) => {
+        allTransformFieldset.querySelectorAll("input[type='range']").forEach((rangeInput) => {
             // Event listeners for when the range inputs change
             rangeInput.addEventListener("input", (el) => {
-                transformFieldset.querySelector(`#${el.target.id.replace("Range", "Num")}`).value = el.target.value;
+                allTransformFieldset.querySelector(`#${el.target.id.replace("Range", "Num")}`).value = el.target.value;
                 updateTransform();
             });
 
             // Reset the relevant transform setting when the range input is double clicked
             rangeInput.addEventListener("dblclick", (el) => {
                 resetInput(el.target);
-                transformFieldset.querySelector(`#${el.target.id.replace("Range", "Num")}`).value = el.target.value;
+                allTransformFieldset.querySelector(`#${el.target.id.replace("Range", "Num")}`).value = el.target.value;
                 updateTransform();
             });
         });
 
         // Event listeners for when the number inputs change
-        transformFieldset.querySelectorAll("input[type='number']").forEach((numInput) => {
+        allTransformFieldset.querySelectorAll("input[type='number']").forEach((numInput) => {
             numInput.addEventListener("input", (el) => {
-                transformFieldset.querySelector(`#${el.target.id.replace("Num", "Range")}`).value = el.target.value;
+                allTransformFieldset.querySelector(`#${el.target.id.replace("Num", "Range")}`).value = el.target.value;
                 updateTransform();
             });
         });
 
         // Individual reset button event listeners
-        transformFieldset.querySelectorAll(".resetButton").forEach((resetButton) => {
+        allTransformFieldset.querySelectorAll(".resetButton").forEach((resetButton) => {
             resetButton.addEventListener("click", (el) => {
-                resetInput(transformFieldset.querySelector(`#${el.target.id.replace("Reset", "Range")}`));
-                resetInput(transformFieldset.querySelector(`#${el.target.id.replace("Reset", "Num")}`));
+                resetInput(allTransformFieldset.querySelector(`#${el.target.id.replace("Reset", "Range")}`));
+                resetInput(allTransformFieldset.querySelector(`#${el.target.id.replace("Reset", "Num")}`));
                 updateTransform();
             });
         });
 
         // Section reset button event listeners
-        transformFieldset.querySelectorAll(".resetSectionButton").forEach((resetSectionButton) => {
+        allTransformFieldset.querySelectorAll(".resetSectionButton").forEach((resetSectionButton) => {
             resetSectionButton.addEventListener("click", (el) => {
                 let allRanges = el.target.parentElement.parentElement.querySelectorAll("input[type='range']");
                 allRanges.forEach((range) => {
@@ -332,35 +410,23 @@
             }
         }
 
-        const resetAllButton = document.querySelector("#resetAllButton");
         resetAllButton.addEventListener("click", () => {
-            transformFieldset.querySelectorAll('input').forEach((input) => {
+            allTransformFieldset.querySelectorAll('input').forEach((input) => {
                 resetInput(input);
             });
             updateTransform();
         });
 
-        const translateXRange = document.querySelector("#translateXRange");
-        const translateYRange = document.querySelector("#translateYRange");
-        const translateZRange = document.querySelector("#translateZRange");
-        const rotateXRange = document.querySelector("#rotateXRange");
-        const rotateYRange = document.querySelector("#rotateYRange");
-        const rotateZRange = document.querySelector("#rotateZRange");
-        const scaleXRange = document.querySelector("#scaleXRange");
-        const scaleYRange = document.querySelector("#scaleYRange");
-        const scaleZRange = document.querySelector("#scaleZRange");
-        const skewXRange = document.querySelector("#skewXRange");
-        const skewYRange = document.querySelector("#skewYRange");
         const updateTransform = () => {
-            cube.style.transform = `translateX(${translateXRange.value}px)
-                translateY(${translateYRange.value}px)
-                translateZ(${translateZRange.value}px)
+            cube.style.transform = `translate3d(${translateXRange.value}px,
+                ${translateYRange.value}px,
+                ${translateZRange.value}px)
                 rotateX(${rotateXRange.value}deg)
                 rotateY(${rotateYRange.value}deg)
                 rotateZ(${rotateZRange.value}deg)
-                scaleX(${scaleXRange.value})
-                scaleY(${scaleYRange.value})
-                scaleZ(${scaleZRange.value})
+                scale3d(${scaleXRange.value},
+                ${scaleYRange.value},
+                ${scaleZRange.value})
                 skewX(${skewXRange.value}deg)
                 skewY(${skewYRange.value}deg)`;
         }

--- a/modules/transforms.html
+++ b/modules/transforms.html
@@ -1,0 +1,371 @@
+<!doctype html>
+<html lang="en-us">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>CSS Transforms</title>
+    <style>
+        #transformFieldset>div {
+            display: flex;
+            flex-direction: column;
+            align-items: start;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        legend {
+            font-size: large;
+            font-weight: bold;
+            padding: 0;
+        }
+
+        #fieldsetContainer {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        fieldset {
+            margin: 0;
+        }
+
+        #cubeContainer {
+            width: 100%;
+            min-height: 400px;
+            perspective: 200px;
+            background: linear-gradient(skyblue, khaki);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        #cube {
+            width: 100px;
+            height: 100px;
+            transform-style: preserve-3d;
+            transition: all 0.075s ease-out;
+        }
+
+        .face {
+            pointer-events: none;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            height: 100%;
+            position: absolute;
+            backface-visibility: inherit;
+            font-size: 60px;
+            color: white;
+        }
+
+        .front {
+            background: rgba(90, 90, 90, 0.7);
+            transform: translateZ(50px);
+        }
+
+        .back {
+            background: rgba(0, 210, 0, 0.7);
+            transform: rotateY(180deg) translateZ(50px);
+        }
+
+        .right {
+            background: rgba(210, 0, 0, 0.7);
+            transform: rotateY(90deg) translateZ(50px);
+        }
+
+        .left {
+            background: rgba(0, 0, 210, 0.7);
+            transform: rotateY(-90deg) translateZ(50px);
+        }
+
+        .top {
+            background: rgba(210, 210, 0, 0.7);
+            transform: rotateX(90deg) translateZ(50px);
+        }
+
+        .bottom {
+            background: rgba(210, 0, 210, 0.7);
+            transform: rotateX(-90deg) translateZ(50px);
+        }
+
+        fieldset,
+        fieldset>div {
+            display: flex;
+            flex-direction: column;
+            align-items: start;
+            gap: 4px;
+        }
+
+        fieldset>div>div,
+        fieldset>div>div>label {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            gap: 4px;
+        }
+
+        fieldset>div>div>label>span {
+            width: 12px;
+            font-size: large;
+        }
+
+        #resetAllButton,
+        .resetSectionButton,
+        .resetButton {
+            font-size: 18px;
+            padding: 0;
+            cursor: pointer;
+            background: none;
+            border: none;
+        }
+
+        input[type='range'] {
+            width: 172px;
+        }
+
+        input[type='number'] {
+            width: 48px;
+        }
+    </style>
+</head>
+
+<body>
+    <article>
+        <fieldset id="transformFieldset">
+            <legend>Transform settings
+                <button id="resetAllButton" aria-label="Reset">↻</button>
+            </legend>
+            <section id="fieldsetContainer">
+                <fieldset>
+                    <legend>Translation (px)
+                        <button id="translateSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
+                    </legend>
+                    <div>
+                        <div>
+                            <label>
+                                <span>X</span>
+                                <input type="range" min="-100" max="100" value="0" id="translateXRange" />
+                            </label>
+                            <input type="number" min="-100" max="100" value="0" id="translateXNum" />
+                            <button id="translateXReset" class="resetButton" aria-label="Reset">↻</button>
+                        </div>
+                        <div>
+                            <label>
+                                <span>Y</span>
+                                <input type="range" min="-100" max="100" value="0" id="translateYRange" />
+                            </label>
+                            <input type="number" min="-100" max="100" value="0" id="translateYNum" />
+                            <button id="translateYReset" class="resetButton" aria-label="Reset">↻</button>
+                        </div>
+                        <div>
+                            <label>
+                                <span>Z</span>
+                                <input type="range" min="-100" max="100" value="0" id="translateZRange" />
+                            </label>
+                            <input type="number" min="-100" max="100" value="0" id="translateZNum" />
+                            <button id="translateZReset" class="resetButton" aria-label="Reset">↻</button>
+                        </div>
+                    </div>
+                </fieldset>
+
+                <fieldset>
+                    <legend>Rotation (deg)
+                        <button id="rotateSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
+                    </legend>
+                    <div>
+                        <div>
+                            <label>
+                                <span>X</span>
+                                <input type="range" min="-360" max="360" value="0" id="rotateXRange" />
+                            </label>
+                            <input type="number" min="-360" max="360" value="0" id="rotateXNum" />
+                            <button id="rotateXReset" class="resetButton" aria-label="Reset">↻</button>
+                        </div>
+                        <div>
+                            <label>
+                                <span>Y</span>
+                                <input type="range" min="-360" max="360" value="0" id="rotateYRange" />
+                            </label>
+                            <input type="number" min="-360" max="360" value="0" id="rotateYNum" />
+                            <button id="rotateYReset" class="resetButton" aria-label="Reset">↻</button>
+                        </div>
+                        <div>
+                            <label>
+                                <span>Z</span>
+                                <input type="range" min="-360" max="360" value="0" id="rotateZRange" />
+                            </label>
+                            <input type="number" min="-360" max="360" value="0" id="rotateZNum" />
+                            <button id="rotateZReset" class="resetButton" aria-label="Reset">↻</button>
+                        </div>
+                    </div>
+                </fieldset>
+
+                <fieldset>
+                    <legend>Scale (factor)
+                        <button id="scaleSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
+                    </legend>
+                    <div>
+                        <div>
+                            <label>
+                                <span>X</span>
+                                <input type="range" min="0.1" max="2.5" value="1" step="0.1" id="scaleXRange" />
+                            </label>
+                            <input type="number" min="0.1" max="2.5" value="1" step="0.1" id="scaleXNum" />
+                            <button id="scaleXReset" class="resetButton" aria-label="Reset">↻</button>
+                        </div>
+                        <div>
+                            <label>
+                                <span>Y</span>
+                                <input type="range" min="0.1" max="2.5" value="1" step="0.1" id="scaleYRange" />
+                            </label>
+                            <input type="number" min="0.1" max="2.5" value="1" step="0.1" id="scaleYNum" />
+                            <button id="scaleYReset" class="resetButton" aria-label="Reset">↻</button>
+                        </div>
+                        <div>
+                            <label>
+                                <span>Z</span>
+                                <input type="range" min="0.1" max="2.5" value="1" step="0.1" id="scaleZRange" />
+                            </label>
+                            <input type="number" min="0.1" max="2.5" value="1" step="0.1" id="scaleZNum" />
+                            <button id="scaleZReset" class="resetButton" aria-label="Reset">↻</button>
+                        </div>
+                    </div>
+                </fieldset>
+
+                <fieldset>
+                    <legend>Skew (deg)
+                        <button id="skewSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
+                    </legend>
+                    <div>
+                        <div>
+                            <label>
+                                <span>X</span>
+                                <input type="range" min="-90" max="90" value="0" id="skewXRange" />
+                            </label>
+                            <input type="number" min="-90" max="90" value="0" id="skewXNum" />
+                            <button id="skewXReset" class="resetButton" aria-label="Reset">↻</button>
+                        </div>
+                        <div>
+                            <label>
+                                <span>Y</span>
+                                <input type="range" min="-90" max="90" value="0" id="skewYRange" />
+                            </label>
+                            <input type="number" min="-90" max="90" value="0" id="skewYNum" />
+                            <button id="skewYReset" class="resetButton" aria-label="Reset">↻</button>
+                        </div>
+                    </div>
+                </fieldset>
+            </section>
+        </fieldset>
+        <section id="cubeContainer">
+            <div id="cube">
+                <div class="face front">1</div>
+                <div class="face back">2</div>
+                <div class="face right">3</div>
+                <div class="face left">4</div>
+                <div class="face top">5</div>
+                <div class="face bottom">6</div>
+            </div>
+        </section>
+    </article>
+    <script>
+        const cube = document.querySelector("#cube");
+
+        const transformFieldset = document.querySelector("#transformFieldset");
+
+        transformFieldset.querySelectorAll("input[type='range']").forEach((rangeInput) => {
+            // Event listeners for when the range inputs change
+            rangeInput.addEventListener("input", (el) => {
+                transformFieldset.querySelector(`#${el.target.id.replace("Range", "Num")}`).value = el.target.value;
+                updateTransform();
+            });
+
+            // Reset the relevant transform setting when the range input is double clicked
+            rangeInput.addEventListener("dblclick", (el) => {
+                resetInput(el.target);
+                transformFieldset.querySelector(`#${el.target.id.replace("Range", "Num")}`).value = el.target.value;
+                updateTransform();
+            });
+        });
+
+        // Event listeners for when the number inputs change
+        transformFieldset.querySelectorAll("input[type='number']").forEach((numInput) => {
+            numInput.addEventListener("input", (el) => {
+                transformFieldset.querySelector(`#${el.target.id.replace("Num", "Range")}`).value = el.target.value;
+                updateTransform();
+            });
+        });
+
+        // Individual reset button event listeners
+        transformFieldset.querySelectorAll(".resetButton").forEach((resetButton) => {
+            resetButton.addEventListener("click", (el) => {
+                resetInput(transformFieldset.querySelector(`#${el.target.id.replace("Reset", "Range")}`));
+                resetInput(transformFieldset.querySelector(`#${el.target.id.replace("Reset", "Num")}`));
+                updateTransform();
+            });
+        });
+
+        // Section reset button event listeners
+        transformFieldset.querySelectorAll(".resetSectionButton").forEach((resetSectionButton) => {
+            resetSectionButton.addEventListener("click", (el) => {
+                let allRanges = el.target.parentElement.parentElement.querySelectorAll("input[type='range']");
+                allRanges.forEach((range) => {
+                    resetInput(range);
+                });
+                let allNums = el.target.parentElement.parentElement.querySelectorAll("input[type='number']");
+                allNums.forEach((num) => {
+                    resetInput(num);
+                });
+                updateTransform();
+            });
+        });
+
+        const resetInput = (inputEl) => {
+            if (inputEl.id.indexOf("scale") > -1) {
+                inputEl.value = "1";
+            } else {
+                inputEl.value = "0";
+            }
+        }
+
+        const resetAllButton = document.querySelector("#resetAllButton");
+        resetAllButton.addEventListener("click", () => {
+            transformFieldset.querySelectorAll('input').forEach((input) => {
+                resetInput(input);
+            });
+            updateTransform();
+        });
+
+        const translateXRange = document.querySelector("#translateXRange");
+        const translateYRange = document.querySelector("#translateYRange");
+        const translateZRange = document.querySelector("#translateZRange");
+        const rotateXRange = document.querySelector("#rotateXRange");
+        const rotateYRange = document.querySelector("#rotateYRange");
+        const rotateZRange = document.querySelector("#rotateZRange");
+        const scaleXRange = document.querySelector("#scaleXRange");
+        const scaleYRange = document.querySelector("#scaleYRange");
+        const scaleZRange = document.querySelector("#scaleZRange");
+        const skewXRange = document.querySelector("#skewXRange");
+        const skewYRange = document.querySelector("#skewYRange");
+        const updateTransform = () => {
+            cube.style.transform = `translateX(${translateXRange.value}px)
+                translateY(${translateYRange.value}px)
+                translateZ(${translateZRange.value}px)
+                rotateX(${rotateXRange.value}deg)
+                rotateY(${rotateYRange.value}deg)
+                rotateZ(${rotateZRange.value}deg)
+                scaleX(${scaleXRange.value})
+                scaleY(${scaleYRange.value})
+                scaleZ(${scaleZRange.value})
+                skewX(${skewXRange.value}deg)
+                skewY(${skewYRange.value}deg)`;
+        }
+        updateTransform();
+    </script>
+</body>
+
+</html>

--- a/modules/transforms.html
+++ b/modules/transforms.html
@@ -40,6 +40,7 @@
             justify-content: center;
             align-items: center;
             position: relative;
+            overflow: clip;
         }
 
         #outputContainer {
@@ -73,12 +74,10 @@
             height: 100px;
             transform-style: preserve-3d;
             transition: all 0.075s ease-out;
-            pointer-events: none;
             position: absolute;
         }
 
         .face {
-            pointer-events: none;
             display: flex;
             align-items: center;
             justify-content: center;

--- a/modules/transforms.html
+++ b/modules/transforms.html
@@ -10,6 +10,8 @@
             border: none;
             padding: 0;
             margin-bottom: 4px;
+            accent-color: blue; /* or any color */
+            font-family: Inter, "system-ui", "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
         }
 
         #allTransformFieldset>legend {
@@ -52,6 +54,7 @@
             justify-content: center;
             align-items: center;
             transform-style: preserve-3d;
+            pointer-events: none;
         }
 
         #z0 {
@@ -65,8 +68,18 @@
             justify-content: center;
             font-size: 14px;
             color: black;
-            border-radius: 100%;
+            border-radius: 50%;
             outline: 1px solid rgba(0, 0, 0, 0.35);
+            pointer-events: all;
+        }
+
+        #perspectiveDot {
+            width: 4px;
+            height: 4px;
+            border-radius: 50%;
+            background-color: rgba(240, 0, 0, 0.5);
+            transform: translate3d(-2px, -2px, 0px);
+            position: absolute;
         }
 
         #cube {
@@ -75,6 +88,7 @@
             transform-style: preserve-3d;
             transition: all 0.075s ease-out;
             position: absolute;
+            pointer-events: all;
         }
 
         .face {
@@ -141,28 +155,6 @@
             gap: 4px;
         }
 
-        @supports selector(:has(*)) {
-
-            .showCheckbox,
-            label:has(input.showCheckbox) {
-                cursor: pointer;
-            }
-
-            .transformFieldset>div {
-                display: none;
-            }
-
-            .transformFieldset:has(>legend>label>input.showCheckbox:checked)>div {
-                display: block;
-            }
-        }
-
-        @supports not selector(:has(*)) {
-            .showCheckbox {
-                display: none;
-            }
-        }
-
         .controlsContainer>div>label {
             display: flex;
             flex-direction: row;
@@ -170,27 +162,22 @@
             gap: 4px;
         }
 
-        .controlsContainer>div>label>span {
-            width: 12px;
-            font-weight: bold;
-        }
-
-        #resetAllButton,
-        .resetSectionButton,
-        .resetButton {
+        button {
             font-size: 18px;
+            border-radius: 50%;
+            border: #ccc solid 1px;
             padding: 0;
-            cursor: pointer;
-            background: none;
-            border: none;
+            width: 26px;
+            height: 26px;
+            margin-left: 4px;
         }
 
         input[type='range'] {
             width: 172px;
         }
 
-        input[type='number'] {
-            width: 48px;
+        output {
+            width: 3em;
         }
     </style>
 </head>
@@ -205,35 +192,31 @@
                 <fieldset class="transformFieldset">
                     <legend>
                         <label>
-                            <input class="showCheckbox" type="checkbox" checked />
-                            <span>Translation (px)</span>
+                            <span>Translation</span>
                         </label>
                         <button id="translateSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
                     </legend>
                     <div class="controlsContainer">
                         <div>
                             <label>
-                                <span>X</span>
-                                <input type="range" min="-100" max="100" value="0" id="translateXRange" />
+                                <span id="translateXLabel">X</span>
+                                <input type="range" min="-100" max="100" value="0" data-default="0" id="translateXRange" aria-labelledby="translateXLabel" />
                             </label>
-                            <input type="number" min="-100" max="100" value="0" id="translateXNum" />
-                            <button id="translateXReset" class="resetButton" aria-label="Reset">↻</button>
+                            <output id="translateXOutput" for="translateXRange"></output>
                         </div>
                         <div>
                             <label>
-                                <span>Y</span>
-                                <input type="range" min="-100" max="100" value="0" id="translateYRange" />
+                                <span id="translateYLabel">Y</span>
+                                <input type="range" min="-100" max="100" value="0" data-default="0" id="translateYRange" aria-labelledby="translateYLabel" />
                             </label>
-                            <input type="number" min="-100" max="100" value="0" id="translateYNum" />
-                            <button id="translateYReset" class="resetButton" aria-label="Reset">↻</button>
+                            <output id="translateYOutput" for="translateYRange"></output>
                         </div>
                         <div>
                             <label>
-                                <span>Z</span>
-                                <input type="range" min="-100" max="100" value="0" id="translateZRange" />
+                                <span id="translateZLabel">Z</span>
+                                <input type="range" min="-100" max="100" value="0" data-default="0" id="translateZRange" aria-labelledby="translateZLabel" />
                             </label>
-                            <input type="number" min="-100" max="100" value="0" id="translateZNum" />
-                            <button id="translateZReset" class="resetButton" aria-label="Reset">↻</button>
+                            <output id="translateZOutput" for="translateZRange"></output>
                         </div>
                     </div>
                 </fieldset>
@@ -241,35 +224,31 @@
                 <fieldset class="transformFieldset">
                     <legend>
                         <label>
-                            <input class="showCheckbox" type="checkbox" />
-                            <span>Rotation (deg)</span>
+                            <span>Rotation</span>
                         </label>
                         <button id="rotateSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
                     </legend>
                     <div class="controlsContainer">
                         <div>
                             <label>
-                                <span>X</span>
-                                <input type="range" min="-360" max="360" value="0" id="rotateXRange" />
+                                <span id="rotateXLabel">X</span>
+                                <input type="range" min="-360" max="360" value="0" data-default="0" id="rotateXRange" aria-labelledby="rotateXLabel" />
                             </label>
-                            <input type="number" min="-360" max="360" value="0" id="rotateXNum" />
-                            <button id="rotateXReset" class="resetButton" aria-label="Reset">↻</button>
+                            <output id="rotateXOutput" for="rotateXRange"></output>
                         </div>
                         <div>
                             <label>
-                                <span>Y</span>
-                                <input type="range" min="-360" max="360" value="0" id="rotateYRange" />
+                                <span id="rotateYLabel">Y</span>
+                                <input type="range" min="-360" max="360" value="0" data-default="0" id="rotateYRange" aria-labelledby="rotateYLabel" />
                             </label>
-                            <input type="number" min="-360" max="360" value="0" id="rotateYNum" />
-                            <button id="rotateYReset" class="resetButton" aria-label="Reset">↻</button>
+                            <output id="rotateYOutput" for="rotateYRange"></output>
                         </div>
                         <div>
                             <label>
-                                <span>Z</span>
-                                <input type="range" min="-360" max="360" value="0" id="rotateZRange" />
+                                <span id="rotateZLabel">Z</span>
+                                <input type="range" min="-360" max="360" value="0" data-default="0" id="rotateZRange" aria-labelledby="rotateZLabel" />
                             </label>
-                            <input type="number" min="-360" max="360" value="0" id="rotateZNum" />
-                            <button id="rotateZReset" class="resetButton" aria-label="Reset">↻</button>
+                            <output id="rotateZOutput" for="rotateZRange"></output>
                         </div>
                     </div>
                 </fieldset>
@@ -277,35 +256,31 @@
                 <fieldset class="transformFieldset">
                     <legend>
                         <label>
-                            <input class="showCheckbox" type="checkbox" />
-                            <span>Scale (factor)</span>
+                            <span>Scale</span>
                         </label>
                         <button id="scaleSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
                     </legend>
                     <div class="controlsContainer">
                         <div>
                             <label>
-                                <span>X</span>
-                                <input type="range" min="0.1" max="2.5" value="1" step="0.1" id="scaleXRange" />
+                                <span id="scaleXLabel">X</span>
+                                <input type="range" min="0.1" max="2.5" value="1" data-default="1" step="0.1" id="scaleXRange" aria-labelledby="scaleXLabel" />
                             </label>
-                            <input type="number" min="0.1" max="2.5" value="1" step="0.1" id="scaleXNum" />
-                            <button id="scaleXReset" class="resetButton" aria-label="Reset">↻</button>
+                            <output id="scaleXOutput" for="scaleXRange"></output>
                         </div>
                         <div>
-                            <label>
+                            <label id="scaleYLabel">
                                 <span>Y</span>
-                                <input type="range" min="0.1" max="2.5" value="1" step="0.1" id="scaleYRange" />
+                                <input type="range" min="0.1" max="2.5" value="1" data-default="1" step="0.1" id="scaleYRange" aria-labelledby="scaleYLabel" />
                             </label>
-                            <input type="number" min="0.1" max="2.5" value="1" step="0.1" id="scaleYNum" />
-                            <button id="scaleYReset" class="resetButton" aria-label="Reset">↻</button>
+                            <output id="scaleYOutput" for="scaleYRange"></output>
                         </div>
                         <div>
-                            <label>
+                            <label id="scaleZLabel">
                                 <span>Z</span>
-                                <input type="range" min="0.1" max="2.5" value="1" step="0.1" id="scaleZRange" />
+                                <input type="range" min="0.1" max="2.5" value="1" data-default="1" step="0.1" id="scaleZRange" aria-labelledby="scaleZLabel" />
                             </label>
-                            <input type="number" min="0.1" max="2.5" value="1" step="0.1" id="scaleZNum" />
-                            <button id="scaleZReset" class="resetButton" aria-label="Reset">↻</button>
+                            <output id="scaleZOutput" for="scaleZRange"></output>
                         </div>
                     </div>
                 </fieldset>
@@ -313,27 +288,73 @@
                 <fieldset class="transformFieldset">
                     <legend>
                         <label>
-                            <input class="showCheckbox" type="checkbox" />
-                            <span>Skew (deg)</span>
+                            <span>Skew</span>
                         </label>
                         <button id="skewSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
                     </legend>
                     <div class="controlsContainer">
                         <div>
                             <label>
-                                <span>X</span>
-                                <input type="range" min="-90" max="90" value="0" id="skewXRange" />
+                                <span id="skewXLabel">X</span>
+                                <input type="range" min="-90" max="90" value="0" data-default="0" id="skewXRange" aria-labelledby="skewXLabel" />
                             </label>
-                            <input type="number" min="-90" max="90" value="0" id="skewXNum" />
-                            <button id="skewXReset" class="resetButton" aria-label="Reset">↻</button>
+                            <output id="skewXOutput" for="skewXRange"></output>
                         </div>
                         <div>
                             <label>
-                                <span>Y</span>
-                                <input type="range" min="-90" max="90" value="0" id="skewYRange" />
+                                <span id="skewYLabel">Y</span>
+                                <input type="range" min="-90" max="90" value="0" data-default="0" id="skewYRange" aria-labelledby="skewYLabel" />
                             </label>
-                            <input type="number" min="-90" max="90" value="0" id="skewYNum" />
-                            <button id="skewYReset" class="resetButton" aria-label="Reset">↻</button>
+                            <output id="skewYOutput" for="skewYRange"></output>
+                        </div>
+                    </div>
+                </fieldset>
+                
+                <fieldset class="transformFieldset">
+                    <legend>
+                        <label>
+                            <span>Container Perspective</span>
+                        </label>
+                        <button id="containerPerspectiveSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
+                    </legend>
+                    <div class="controlsContainer">
+                        <div>
+                            <label>
+                                <span id="perspectiveLabel"><code>perspective</code></span>
+                                <input type="range" min="75" max="500" value="200" data-default="200" id="perspectiveRange" aria-labelledby="perspectiveLabel" />
+                            </label>
+                            <output id="perspectiveOutput" for="perspectiveRange"></output>
+                        </div>
+                        <div>
+                            <label>
+                                <span id="perspectiveOriginXLabel"><code>perspective-origin</code> X (%)</span>
+                                <input type="range" min="0" max="100" value="50" data-default="50" id="perspectiveOriginXRange" aria-labelledby="perspectiveOriginXLabel" />
+                            </label>
+                            <output id="perspectiveOriginXOutput" for="perspectiveOriginXRange"></output>
+                        </div>
+                        <div>
+                            <label>
+                                <span><code>perspective-origin</code> Y (%)</span>
+                                <input type="range" min="0" max="100" value="50" data-default="50" id="perspectiveOriginYRange" aria-labelledby="perspectiveOriginYLabel" />
+                            </label>
+                            <output id="perspectiveOriginYOutput" for="perspectiveOriginYRange"></output>
+                        </div>
+                    </div>
+                </fieldset>
+                
+                <fieldset class="transformFieldset">
+                    <legend>
+                        <label>
+                            <span>Other Properties</span>
+                        </label>
+                        <button id="otherSectionReset" class="resetSectionButton" aria-label="Reset">↻</button>
+                    </legend>
+                    <div class="controlsContainer">
+                        <div>
+                            <label>
+                                <span><code>backface-visibility</code></span>
+                                <input type="checkbox" checked="checked" data-default="checked" id="backfaceVisibilityCheckbox" />
+                            </label>
                         </div>
                     </div>
                 </fieldset>
@@ -351,39 +372,36 @@
                 </div>
                 <div id="z0"><code>z:0px</code></div>
             </div>
+            <div id="perspectiveDot"></div>
         </section>
     </article>
     <script>
         allTransformFieldset.querySelectorAll("input[type='range']").forEach((rangeInput) => {
             // Event listeners for when the range inputs change
             rangeInput.addEventListener("input", (el) => {
-                allTransformFieldset.querySelector(`#${el.target.id.replace("Range", "Num")}`).value = el.target.value;
                 updateTransform();
             });
 
             // Reset the relevant transform setting when the range input is double clicked
             rangeInput.addEventListener("dblclick", (el) => {
                 resetInput(el.target);
-                allTransformFieldset.querySelector(`#${el.target.id.replace("Range", "Num")}`).value = el.target.value;
                 updateTransform();
             });
         });
 
-        // Event listeners for when the number inputs change
-        allTransformFieldset.querySelectorAll("input[type='number']").forEach((numInput) => {
-            numInput.addEventListener("input", (el) => {
-                allTransformFieldset.querySelector(`#${el.target.id.replace("Num", "Range")}`).value = el.target.value;
+        // Event listeners for when checkbox inputs change
+        allTransformFieldset.querySelectorAll("input[type='checkbox']").forEach((checkboxInput) => {
+            checkboxInput.addEventListener("input", (el) => {
                 updateTransform();
             });
         });
-
-        // Individual reset button event listeners
-        allTransformFieldset.querySelectorAll(".resetButton").forEach((resetButton) => {
-            resetButton.addEventListener("click", (el) => {
-                resetInput(allTransformFieldset.querySelector(`#${el.target.id.replace("Reset", "Range")}`));
-                resetInput(allTransformFieldset.querySelector(`#${el.target.id.replace("Reset", "Num")}`));
-                updateTransform();
+        
+        // "Reset All" button event listener
+        resetAllButton.addEventListener("click", () => {
+            allTransformFieldset.querySelectorAll('input').forEach((input) => {
+                resetInput(input);
             });
+            updateTransform();
         });
 
         // Section reset button event listeners
@@ -393,30 +411,56 @@
                 allRanges.forEach((range) => {
                     resetInput(range);
                 });
-                let allNums = el.target.parentElement.parentElement.querySelectorAll("input[type='number']");
-                allNums.forEach((num) => {
-                    resetInput(num);
+
+                let allCheckboxes = el.target.parentElement.parentElement.querySelectorAll("input[type='checkbox']");
+                allCheckboxes.forEach((check) => {
+                    resetInput(check);
                 });
+
                 updateTransform();
             });
         });
 
         const resetInput = (inputEl) => {
-            if (inputEl.id.indexOf("scale") > -1) {
-                inputEl.value = "1";
+            if (!inputEl) {
+                console.warn(`inputEl \`${inputEl}\` is falsey!`);
+                console.trace();
+                return;
+            }
+
+            const defaultValue = inputEl.getAttribute("data-default");
+            if (inputEl.getAttribute('type') === 'checkbox') {
+                inputEl.checked = defaultValue === "checked";
             } else {
-                inputEl.value = "0";
+                inputEl.value = defaultValue || "0";
             }
         }
 
-        resetAllButton.addEventListener("click", () => {
-            allTransformFieldset.querySelectorAll('input').forEach((input) => {
-                resetInput(input);
-            });
-            updateTransform();
-        });
+        const updateOutputs = () => {
+            translateXOutput.value = `${parseInt(translateXRange.value)}px`;
+            translateYOutput.value = `${parseInt(translateYRange.value)}px`;
+            translateZOutput.value = `${parseInt(translateZRange.value)}px`;
+            
+            rotateXOutput.value = `${parseInt(rotateXRange.value)}°`;
+            rotateYOutput.value = `${parseInt(rotateYRange.value)}°`;
+            rotateZOutput.value = `${parseInt(rotateZRange.value)}°`;
+            
+            scaleXOutput.value = `${parseFloat(scaleXRange.value)}x`;
+            scaleYOutput.value = `${parseFloat(scaleYRange.value)}x`;
+            scaleZOutput.value = `${parseFloat(scaleZRange.value)}x`;
+            
+            skewXOutput.value = `${parseFloat(skewXRange.value)}°`;
+            skewYOutput.value = `${parseFloat(skewYRange.value)}°`;
+
+            perspectiveOutput.value = `${parseInt(perspectiveRange.value)}px`;
+
+            perspectiveOriginXOutput.value = `${parseInt(perspectiveOriginXRange.value)}%`;
+            perspectiveOriginYOutput.value = `${parseInt(perspectiveOriginYRange.value)}%`;
+        }
 
         const updateTransform = () => {
+            updateOutputs();
+
             cube.style.transform = `translate3d(${translateXRange.value}px,
                 ${translateYRange.value}px,
                 ${translateZRange.value}px)
@@ -428,6 +472,13 @@
                 ${scaleZRange.value})
                 skewX(${skewXRange.value}deg)
                 skewY(${skewYRange.value}deg)`;
+            cube.style.backfaceVisibility = `${backfaceVisibilityCheckbox.checked ? 'visible' : 'hidden'}`;
+            
+            outputContainer.style.perspective = `${perspectiveRange.value}px`;
+            outputContainer.style.perspectiveOrigin = `${perspectiveOriginXRange.value}% ${perspectiveOriginYRange.value}%`;
+
+            perspectiveDot.style.top = `${perspectiveOriginYRange.value}%`;
+            perspectiveDot.style.left = `${perspectiveOriginXRange.value}%`;
         }
         updateTransform();
     </script>


### PR DESCRIPTION
_(The below is copy/pasted from [the Content PR's](https://github.com/mdn/content/pull/30783) text.)_

### Description

1. Improves the existing CSS Transforms module with a powerful new interactive example and additional prose for context.
2. Implements a new guide related to CSS transforms called "Styling animated buttons with CSS transforms"

### Motivation

Main motivation: Improving our documentation as a part of [the Interop 2023 project](https://github.com/mdn/mdn/issues/416).

### Related issues and pull requests

- `content` PR (for additional module prose and new guide): https://github.com/mdn/content/pull/30783
- `css-examples` PR (for the module page's "CSS transforms in action" interactive example section): https://github.com/mdn/css-examples/pull/160
- `yari` PR (for sidebar changes): https://github.com/mdn/yari/pull/10127

Once these three PRs are merged, https://github.com/mdn/mdn/issues/488 will be resolved.