### PR TITLE
feat: add 'copy css' button to tools/border-image-generator

### DIFF
--- a/tools/border-image-generator/index.html
+++ b/tools/border-image-generator/index.html
@@ -148,7 +148,7 @@
         </div>
 
         <div id="output" class="category">
-          <div class="title">CSS Code</div>
+          <div class="title">CSS Code <button type="button" id="copy-css">Click to Copy</button></div>
           <div class="css-property">
             <span class="name"> border-image-slice: </span>
             <span id="out-border-slice" class="value"> </span>

--- a/tools/border-image-generator/index.html
+++ b/tools/border-image-generator/index.html
@@ -148,7 +148,9 @@
         </div>
 
         <div id="output" class="category">
-          <div class="title">CSS Code <button type="button" id="copy-css">Click to Copy</button></div>
+          <div class="title">
+            CSS Code <button type="button" id="copy-css">Click to Copy</button>
+          </div>
           <div class="css-property">
             <span class="name"> border-image-slice: </span>
             <span id="out-border-slice" class="value"> </span>

--- a/tools/border-image-generator/script.js
+++ b/tools/border-image-generator/script.js
@@ -1282,7 +1282,7 @@ var BorderImage = (function BorderImage() {
         navigator.clipboard.writeText(output)
       };
 
-      copyButton.addEventListener("onclick", copy);
+      copyButton.addEventListener("click", copy);
     };
 
     var init = function init() {

--- a/tools/border-image-generator/script.js
+++ b/tools/border-image-generator/script.js
@@ -1266,6 +1266,25 @@ var BorderImage = (function BorderImage() {
       }
     };
 
+    var initCodeOutput = function initCodeOutput() {
+      var copyButton = getElemById("copy-css");
+
+      var copy = function copy() {
+        let output = ""
+
+        for (const property of document.querySelectorAll(".css-property")) {
+          const name = property.querySelector(".name").innerText;
+          const value = property.querySelector(".value").innerText;
+
+          output += name+" "+value+"\n"
+        }
+
+        navigator.clipboard.writeText(output)
+      };
+
+      copyButton.addEventListener("mousedown", copy);
+    };
+
     var init = function init() {
       var gallery = (subject = getElemById("subject"));
       preview = getElemById("preview");
@@ -1280,6 +1299,7 @@ var BorderImage = (function BorderImage() {
       initBorderSliceControls();
       initBorderWidthControls();
       initBorderOutsetControls();
+      initCodeOutput();
 
       var elem = document.querySelectorAll(".guideline");
       var size = elem.length;

--- a/tools/border-image-generator/script.js
+++ b/tools/border-image-generator/script.js
@@ -1270,16 +1270,16 @@ var BorderImage = (function BorderImage() {
       var copyButton = getElemById("copy-css");
 
       var copy = function copy() {
-        let output = ""
+        let output = "";
 
         for (const property of document.querySelectorAll(".css-property")) {
           const name = property.querySelector(".name").innerText;
           const value = property.querySelector(".value").innerText;
 
-          output += name+" "+value+"\n"
+          output += name + " " + value + "\n";
         }
 
-        navigator.clipboard.writeText(output)
+        navigator.clipboard.writeText(output);
       };
 
       copyButton.addEventListener("click", copy);

--- a/tools/border-image-generator/script.js
+++ b/tools/border-image-generator/script.js
@@ -1282,7 +1282,7 @@ var BorderImage = (function BorderImage() {
         navigator.clipboard.writeText(output)
       };
 
-      copyButton.addEventListener("mousedown", copy);
+      copyButton.addEventListener("onclick", copy);
     };
 
     var init = function init() {

--- a/tools/border-image-generator/styles.css
+++ b/tools/border-image-generator/styles.css
@@ -972,6 +972,25 @@ body[data-move="Y"] {
   color: #aaa;
 }
 
+#output .title #copy-css {
+  float: right;
+
+  background-color: unset;
+  color: inherit;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  box-shadow: 0 0 3px 0 #bababa;
+}
+
+#controls .category:hover #copy-css:not(:hover) {
+  color: #aaa;
+}
+
+#output .title #copy-css:hover {
+  cursor: pointer;
+  color: #777;
+}
+
 #output .css-property {
   width: 100%;
   margin: 0;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

**Description:**

This PR adds a 'click to copy' button to the CSS code output of the Border Image Generator tool.

<!-- ✍️ Summarize your changes in one or two sentences -->

**Motivation:**

I'm proposing this change as it improves the QOL of the border image tool, especially when rapidly iterating various options for border images. The copy button is out of the way and shouldn't interfere with any existing workflows.

<!-- ❓ Why are you making these changes and how do they help readers? -->

**Additional details:**

- The button is styled to maintain consistency with the rest of the document. Firefox reports an accessibility error due to a low text contrast of 4.58, however, the same error is raised for other existing text elements, so I figure this is OK to leave as-is.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

**Related issues and pull requests:**

- I couldn't find any related GitHub issues
- I couldn't find any related pull requests
- This PR doesn't depend on other branches

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

This is my first PR to `mdn/css-examples` (or, any `mdn` repository), so I apologize if I've missed any contributing steps! Let me know if there's any issues - I'm happy to make any necessary changes :)
