### PR TITLE
fix: update `border-image-slice` value when fill is toggled (fixes #63)

### DIFF
--- a/tools/border-image-generator/script.js
+++ b/tools/border-image-generator/script.js
@@ -1109,6 +1109,7 @@ var BorderImage = (function BorderImage() {
       if (value === true) bimgslice += " fill";
 
       preview.style.borderImageSlice = bimgslice;
+      setOutputCSS("slice", bimgslice);
     };
 
     var updateBorderWidth = function updateBorderWidth() {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

**Description:**

This PR updates the Border Image Generator tool, fixing a bug where the CSS code output is not updated when the fill checkbox is toggled.

<!-- ✍️ Summarize your changes in one or two sentences -->

**Motivation:**

Before this PR, the "CSS Code" section of the tool would not update the `border-image-slice` property when the fill value is toggled. This can lead to an inconsistency between given inputs and the resulting outputs. This PR fixes that by calling `setOutputCSS` inside the `setBorderFill` function, bringing it in-line with the behaviour of the `setBorderSlice` function.

<!-- ❓ Why are you making these changes and how do they help readers? -->

**Additional details:**

- Can't think of any extra information, this PR is a single-line change so there shouldn't be many issues.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

**Related issues and pull requests:**

- #63 references this problem, which is fixed and can be closed by this PR.
- I couldn't find any related pull requests.
- This PR doesn't depend on any other branches.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
