### PR TITLE
Fix CSS Normal Flow: Inline demo

### DIFF
--- a/flow/block-inline/inline.html
+++ b/flow/block-inline/inline.html
@@ -74,7 +74,7 @@
     <textarea id="code" class="playable-html">
     <p>Before that night—<strong>a memorable night</strong>, as it was to prove—hundreds of millions of people had watched the rising smoke-wreaths of their fires without drawing any special inspiration from the fact.”</p>
     </textarea>
-    
+
     <div class="playable-buttons">
       <input id="reset" type="button" value="Reset" />
     </div>

--- a/flow/block-inline/inline.html
+++ b/flow/block-inline/inline.html
@@ -63,7 +63,7 @@
 
   <body>
     <section>
-      <p>
+      <p class="editable">
         Before that night—<strong>a memorable night</strong>, as it was to
         prove—hundreds of millions of people had watched the rising
         smoke-wreaths of their fires without drawing any special inspiration
@@ -71,7 +71,7 @@
       </p>
     </section>
 
-    <textarea id="code" class="playable-html">
+    <textarea id="code" class="playable-html playable-css">
 
   <p>Before that night—<strong>a memorable night</strong>, as it was to prove—hundreds of millions of people had watched the rising smoke-wreaths of their fires without drawing any special inspiration from the fact.”</p></textarea
     >

--- a/flow/block-inline/inline.html
+++ b/flow/block-inline/inline.html
@@ -63,7 +63,7 @@
 
   <body>
     <section>
-      <p class="editable">
+      <p>
         Before that night—<strong>a memorable night</strong>, as it was to
         prove—hundreds of millions of people had watched the rising
         smoke-wreaths of their fires without drawing any special inspiration
@@ -71,36 +71,30 @@
       </p>
     </section>
 
-    <textarea id="code" class="playable-html playable-css">
-
-  <p>Before that night—<strong>a memorable night</strong>, as it was to prove—hundreds of millions of people had watched the rising smoke-wreaths of their fires without drawing any special inspiration from the fact.”</p></textarea
-    >
+    <textarea id="code" class="playable-html">
+    <p>Before that night—<strong>a memorable night</strong>, as it was to prove—hundreds of millions of people had watched the rising smoke-wreaths of their fires without drawing any special inspiration from the fact.”</p>
+    </textarea>
+    
     <div class="playable-buttons">
       <input id="reset" type="button" value="Reset" />
     </div>
   </body>
   <script>
     var section = document.querySelector("section");
-    var editable = document.querySelector(".editable");
     var textareaHTML = document.querySelector(".playable-html");
-    var textareaCSS = document.querySelector(".playable-css");
     var reset = document.getElementById("reset");
     var htmlCode = textareaHTML.value;
-    var cssCode = textareaCSS.value;
 
     function fillCode() {
-      editable.innerHTML = textareaCSS.value;
       section.innerHTML = textareaHTML.value;
     }
 
     reset.addEventListener("click", function () {
       textareaHTML.value = htmlCode;
-      textareaCSS.value = cssCode;
       fillCode();
     });
 
     textareaHTML.addEventListener("input", fillCode);
-    textareaCSS.addEventListener("input", fillCode);
     window.addEventListener("load", fillCode);
   </script>
 </html>


### PR DESCRIPTION
Fixes the issue mdn/content#33705

**Description:**

MDN URL
https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout/Block_and_inline_layout_in_normal_flow

The first code example in the `Elements participating in an inline formatting context` 
section is not interactive and `Reset` button wasn't working.

This PR fixes the issue.

**Motivation:**
.

**Additional details:**
.

**Related issues and pull requests:**
.

