### PR TITLE
fix(tool): color-mix tool increase height of the output text

### DIFF
--- a/tools/color-mixer/index.html
+++ b/tools/color-mixer/index.html
@@ -72,6 +72,7 @@
         margin: 1rem auto;
         font-weight: bold;
         font-size: 0.8rem;
+        height: 2.5rem;
       }
 
       #color-mixer > :nth-child(10) {


### PR DESCRIPTION
When the output text wraps the controls get pushed down:

https://github.com/mdn/css-examples/assets/87750369/b6909327-9778-4c9e-bf1c-7d31816bb46c

## Solution

Increase output text height.
