### PR TITLE
width of flex ratio examples

### DIFF
--- a/flexbox/ratios/flex-basis.html
+++ b/flexbox/ratios/flex-basis.html
@@ -41,6 +41,7 @@
         text-align: right;
         width: 90%;
         max-width: 700px;
+        min-width: 500px;
         padding: 5px 10px 5px 26px;
         font-size: 100%;
       }
@@ -48,6 +49,7 @@
       section {
         width: 90%;
         max-width: 700px;
+        min-width: 500px;
         border: 1px solid #4d4e53;
         border-radius: 2px;
         padding: 10px 14px 10px 10px;

--- a/flexbox/ratios/flex-grow.html
+++ b/flexbox/ratios/flex-grow.html
@@ -41,6 +41,7 @@
         text-align: right;
         width: 90%;
         max-width: 700px;
+        min-width: 500px;
         padding: 5px 10px 5px 26px;
         font-size: 100%;
       }
@@ -48,6 +49,7 @@
       section {
         width: 90%;
         max-width: 700px;
+        min-width: 500px;
         border: 1px solid #4d4e53;
         border-radius: 2px;
         padding: 10px 14px 10px 10px;

--- a/flexbox/ratios/flex-shrink-min-content.html
+++ b/flexbox/ratios/flex-shrink-min-content.html
@@ -41,6 +41,7 @@
         text-align: right;
         width: 90%;
         max-width: 700px;
+        min-width: 500px;
         padding: 5px 10px 5px 26px;
         font-size: 100%;
       }
@@ -48,6 +49,7 @@
       section {
         width: 90%;
         max-width: 700px;
+        min-width: 500px;
         border: 1px solid #4d4e53;
         border-radius: 2px;
         padding: 10px 14px 10px 10px;

--- a/flexbox/ratios/flex-shrink-ratios.html
+++ b/flexbox/ratios/flex-shrink-ratios.html
@@ -41,6 +41,7 @@
         text-align: right;
         width: 90%;
         max-width: 700px;
+        min-width: 500px;
         padding: 5px 10px 5px 26px;
         font-size: 100%;
       }
@@ -48,6 +49,7 @@
       section {
         width: 90%;
         max-width: 700px;
+        min-width: 500px;
         border: 1px solid #4d4e53;
         border-radius: 2px;
         padding: 10px 14px 10px 10px;

--- a/flexbox/ratios/flex-shrink.html
+++ b/flexbox/ratios/flex-shrink.html
@@ -41,6 +41,7 @@
         text-align: right;
         width: 90%;
         max-width: 700px;
+        min-width: 500px;
         padding: 5px 10px 5px 26px;
         font-size: 100%;
       }
@@ -48,6 +49,7 @@
       section {
         width: 90%;
         max-width: 700px;
+        min-width: 500px;
         border: 1px solid #4d4e53;
         border-radius: 2px;
         padding: 10px 14px 10px 10px;


### PR DESCRIPTION
confusing lesson when the flex container is wider than the viewport. this fixes that.