### PR TITLE
Fix incorrect color named in example

### DIFF
--- a/feature-queries/simple.html
+++ b/feature-queries/simple.html
@@ -25,7 +25,7 @@
     <section class="preview">
       <div class="box">
         If your browser supports row-gap, border will be be dashed and text will
-        be darkgreen
+        be red
       </div>
     </section>
 
@@ -44,7 +44,7 @@
 
     <textarea class="playable playable-html" style="height: 120px">
 <div class="box">
-If your browser supports row-gap, border will be be dashed and text will be darkgreen
+If your browser supports row-gap, border will be be dashed and text will be red
 </div></textarea
     >
 


### PR DESCRIPTION
Border is darkgreen but text color is red.

**Description:**

The example text references the wrong color to expect when the feature is supported.

**Motivation:**

Avoiding confusion while learning on MDN.